### PR TITLE
remove unused indexes

### DIFF
--- a/db/migrate/201604121130200_builds_drop_index_owner_type.rb
+++ b/db/migrate/201604121130200_builds_drop_index_owner_type.rb
@@ -1,0 +1,11 @@
+class BuildsDropIndexOwnerType < ActiveRecord::Migration
+  self.disable_ddl_transaction!
+
+  def up
+    execute "DROP INDEX CONCURRENTLY index_builds_on_owner_type"
+  end
+
+  def down
+    execute "CREATE INDEX CONCURRENTLY index_builds_on_owner_type ON builds (owner_type)"
+  end
+end

--- a/db/migrate/201604121130700_repositories_drop_index_last_build_started_at.rb
+++ b/db/migrate/201604121130700_repositories_drop_index_last_build_started_at.rb
@@ -1,0 +1,11 @@
+class RepositoriesDropIndexLastBuildStartedAt < ActiveRecord::Migration
+  self.disable_ddl_transaction!
+
+  def up
+    execute "DROP INDEX CONCURRENTLY index_repositories_on_last_build_started_at"
+  end
+
+  def down
+    execute "CREATE INDEX CONCURRENTLY index_repositories_on_last_build_started_at ON builds (last_build_started_at)"
+  end
+end

--- a/db/migrate/20160412121405_jobs_drop_index_type.rb
+++ b/db/migrate/20160412121405_jobs_drop_index_type.rb
@@ -1,0 +1,11 @@
+class JobsDropIndexSourceType < ActiveRecord::Migration
+  self.disable_ddl_transaction!
+
+  def up
+    execute "DROP INDEX CONCURRENTLY index_jobs_on_source_type"
+  end
+
+  def down
+    execute "CREATE INDEX CONCURRENTLY index_jobs_on_source_type ON jobs (source_type)"
+  end
+end

--- a/db/migrate/20160412123900_jobs_drop_index_source_type.rb
+++ b/db/migrate/20160412123900_jobs_drop_index_source_type.rb
@@ -1,0 +1,11 @@
+class JobsDropIndexSourceType < ActiveRecord::Migration
+  self.disable_ddl_transaction!
+
+  def up
+    execute "DROP INDEX CONCURRENTLY index_jobs_on_source_type"
+  end
+
+  def down
+    execute "CREATE INDEX CONCURRENTLY index_jobs_on_source_type ON jobs (source_type)"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1287,13 +1287,6 @@ CREATE INDEX index_builds_on_owner_id ON builds USING btree (owner_id);
 
 
 --
--- Name: index_builds_on_owner_type; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_builds_on_owner_type ON builds USING btree (owner_type);
-
-
---
 -- Name: index_builds_on_repository_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -1371,24 +1364,10 @@ CREATE INDEX index_jobs_on_source_id ON jobs USING btree (source_id);
 
 
 --
--- Name: index_jobs_on_source_type; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_jobs_on_source_type ON jobs USING btree (source_type);
-
-
---
 -- Name: index_jobs_on_state; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
 CREATE INDEX index_jobs_on_state ON jobs USING btree (state);
-
-
---
--- Name: index_jobs_on_type; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_jobs_on_type ON jobs USING btree (type);
 
 
 --
@@ -1473,13 +1452,6 @@ CREATE INDEX index_repositories_on_active ON repositories USING btree (active);
 --
 
 CREATE UNIQUE INDEX index_repositories_on_github_id ON repositories USING btree (github_id);
-
-
---
--- Name: index_repositories_on_last_build_started_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_repositories_on_last_build_started_at ON repositories USING btree (last_build_started_at);
 
 
 --
@@ -1996,3 +1968,11 @@ INSERT INTO schema_migrations (version) VALUES ('20151202122200');
 INSERT INTO schema_migrations (version) VALUES ('20160107120927');
 
 INSERT INTO schema_migrations (version) VALUES ('20160303165750');
+
+INSERT INTO schema_migrations (version) VALUES ('201604121130200');
+
+INSERT INTO schema_migrations (version) VALUES ('201604121130700');
+
+INSERT INTO schema_migrations (version) VALUES ('20160412121405');
+
+INSERT INTO schema_migrations (version) VALUES ('20160412123900');


### PR DESCRIPTION
This addresses this issue: https://github.com/travis-pro/team-teal/issues/778

It removes the following indexes:
 `index_jobs_on_type`
 `index_jobs_on_source_type`
 `index_builds_on_owner_type`
 `index_repositories_on_last_build_started_at`

It HAS NOT removed the `index_commits_on_repository_id` index as this is one that @henrikhodne uses occasionally when debugging.