### PR TITLE
add index builds on number

### DIFF
--- a/db/migrate/20160422104300_builds_add_index_number.rb
+++ b/db/migrate/20160422104300_builds_add_index_number.rb
@@ -1,0 +1,11 @@
+class BuildsAddIndexNumber < ActiveRecord::Migration
+  self.disable_ddl_transaction!
+
+  def up
+    execute "CREATE INDEX CONCURRENTLY index_builds_on_number ON builds (number)"
+  end
+
+  def down
+    execute "DROP INDEX CONCURRENTLY index_builds_on_number"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1280,6 +1280,13 @@ CREATE INDEX index_builds_on_event_type ON builds USING btree (event_type);
 
 
 --
+-- Name: index_builds_on_number; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_builds_on_number ON builds USING btree (number);
+
+
+--
 -- Name: index_builds_on_owner_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -1985,3 +1992,5 @@ INSERT INTO schema_migrations (version) VALUES ('20160412121405');
 INSERT INTO schema_migrations (version) VALUES ('20160412123900');
 
 INSERT INTO schema_migrations (version) VALUES ('20160414214442');
+
+INSERT INTO schema_migrations (version) VALUES ('20160422104300');


### PR DESCRIPTION
This adds an index for `number` on the builds table.
It should help API queries that include `after_number` in the params, eg `.../builds?after_number=1500`.

