### PR TITLE
Add previous_job_states table and triggers to fill it

### DIFF
--- a/db/migrate/20160623133900_create_previous_job_states.rb
+++ b/db/migrate/20160623133900_create_previous_job_states.rb
@@ -1,0 +1,12 @@
+class CreatePreviousJobStates < ActiveRecord::Migration
+  def change
+    create_table :previous_job_states do |t|
+      t.belongs_to :job
+      t.datetime :set_at
+      t.datetime :ended_at
+      t.string :state
+    end
+
+    add_column :jobs, :previous_job_state_id, :bigint
+  end
+end

--- a/db/migrate/20160623133901_add_previous_states_triggers.rb
+++ b/db/migrate/20160623133901_add_previous_states_triggers.rb
@@ -1,0 +1,41 @@
+class AddPreviousStatesTriggers < ActiveRecord::Migration
+  def up
+    execute <<-SQL
+      CREATE FUNCTION save_state_change() RETURNS trigger AS $$
+      DECLARE
+        previous_job_state_id BIGINT;
+      BEGIN
+        if TG_OP='UPDATE' then
+          UPDATE previous_job_states SET ended_at = NOW() WHERE id = OLD.previous_job_state_id;
+        end if;
+
+        INSERT INTO previous_job_states (job_id, set_at, state) VALUES(NEW.id, NOW(), NEW.state)
+          RETURNING id INTO previous_job_state_id;
+        NEW.previous_job_state_id = previous_job_state_id;
+
+        RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql;
+
+      CREATE TRIGGER save_state_change_on_update
+      BEFORE UPDATE on jobs
+      FOR EACH ROW
+      WHEN (OLD.state IS DISTINCT FROM NEW.state)
+      EXECUTE PROCEDURE save_state_change();
+
+      CREATE TRIGGER save_state_change_on_insert
+      BEFORE INSERT on jobs
+      FOR EACH ROW
+      EXECUTE PROCEDURE save_state_change();
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      DROP TRIGGER IF EXISTS save_state_change_on_update on jobs;
+      DROP TRIGGER IF EXISTS save_state_change_on_insert on jobs;
+      DROP FUNCTION IF EXISTS save_state_change();
+    SQL
+  end
+end
+


### PR DESCRIPTION
I need to have a list of previous states of each job to write a tool for
displaying builds execution history (currently this information is lost
whenever the job is restarted). Ideally I would save this information in
a JSONB column, but we're on postgresql 9.3, so neither JSONB nor
functions to modify it are available.