### PR TITLE
Add pro-migrations files into migrations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,5 +28,3 @@ install:
 
 before_script:
   - 'cp config/database.yml.travis config/database.yml'
-  - 'RAILS_ENV=test bundle exec rake db:create --trace'
-  - 'RAILS_ENV=test bundle exec rake db:migrate'

--- a/README.md
+++ b/README.md
@@ -35,23 +35,25 @@ Running migrations locally
 
 
 To setup the database from scratch:
-(this creates the DEVELOPMENT database, to create the TEST database, append RAILS_ENV=test to each command)
+<em>(PLEASE NOTE: the DATABASE_NAME is the name of the local database you wish to create or run migrations on, either `travis_development`, `travis_pro_development`, `travis_test`, or `travis_pro_test`)</em>
 
 ``` bash
-bundle exec rake db:create
+DATABASE_NAME=<database_name> bundle exec rake db:create
 ```
 
 To run migrations after the database has been set up:
 
 ``` bash
-bundle exec rake db:migrate
+DATABASE_NAME=<database_name> bundle exec rake db:migrate
 ```
+
+
 
 To run a standalone migration:
 (replace `<timestamp>`with the timestamp of the migration you want to run.)
 
 ``` bash
-bundle exec rake db:migrate VERSION=<timestamp>
+DATABASE_NAME=<database_name> bundle exec rake db:migrate VERSION=<timestamp>
 ```
 
 
@@ -66,6 +68,5 @@ Replace `<timestamp>` with the timestamp of the migration you want to run.
 git push git@heroku.com:<app>.git
 heroku run bundle exec rake db:migrate VERSION=<timestamp> -a <app>
 ```
-<em>PLEASE NOTE: Any .com related migrations must be run using [`travis-pro-migrations`](https://github.com/travis-pro/travis-pro-migrations). Please refer to the README in that repository.</em>
 
 ----

--- a/config/database.yml
+++ b/config/database.yml
@@ -11,8 +11,8 @@ defaults: &defaults
 
 development:
   <<: *defaults
-  database: travis_development
+  database: <%= ENV.fetch('DATABASE_NAME', 'travis_development') %>
 
 test:
   <<: *defaults
-  database: travis_test
+  database: <%= ENV.fetch('DATABASE_NAME', 'travis_test') %>

--- a/db/migrate/20120702111126_create_subscriptions.rb
+++ b/db/migrate/20120702111126_create_subscriptions.rb
@@ -1,0 +1,21 @@
+class CreateSubscriptions < ActiveRecord::Migration
+  def change
+    create_table :subscriptions do |t|
+      t.string :cc_token
+      t.datetime :valid_to
+      t.belongs_to :owner, :polymorphic => true
+      t.string :first_name
+      t.string :last_name
+      t.string :company
+      t.string :zip_code
+      t.string :address
+      t.string :address2
+      t.string :city
+      t.string :state
+      t.string :country
+      t.string :vat_id
+      t.string :customer_id
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20120703114226_add_billing_email_credit_card_data_to_subscriptions.rb
+++ b/db/migrate/20120703114226_add_billing_email_credit_card_data_to_subscriptions.rb
@@ -1,0 +1,10 @@
+class AddBillingEmailCreditCardDataToSubscriptions < ActiveRecord::Migration
+  def change
+    change_table :subscriptions do |t|
+      t.string :cc_owner
+      t.string :cc_last_digits
+      t.string :cc_expiration_date
+      t.string :billing_email
+    end
+  end
+end

--- a/db/migrate/201207261749_create_plans.rb
+++ b/db/migrate/201207261749_create_plans.rb
@@ -1,0 +1,12 @@
+class CreatePlans < ActiveRecord::Migration
+  def change
+    create_table :plans do |t|
+      t.string :name
+      t.string :coupon
+      t.belongs_to :subscription
+      t.datetime :valid_from
+      t.datetime :valid_to
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20120731074000_add_amount_to_plans.rb
+++ b/db/migrate/20120731074000_add_amount_to_plans.rb
@@ -1,0 +1,7 @@
+class AddAmountToPlans < ActiveRecord::Migration
+  def change
+    change_table :plans do |t|
+      t.integer :amount
+    end
+  end
+end

--- a/db/migrate/20120803164000_create_invoices.rb
+++ b/db/migrate/20120803164000_create_invoices.rb
@@ -1,0 +1,9 @@
+class CreateInvoices < ActiveRecord::Migration
+  def change
+    create_table :invoices do |t|
+      t.text :object
+      t.timestamps
+      t.belongs_to :subscription
+    end
+  end
+end

--- a/db/migrate/20120803182300_add_invoice_id_to_invoices.rb
+++ b/db/migrate/20120803182300_add_invoice_id_to_invoices.rb
@@ -1,0 +1,7 @@
+class AddInvoiceIdToInvoices < ActiveRecord::Migration
+  def change
+    change_table :invoices do |t|
+      t.string :invoice_id
+    end
+  end
+end

--- a/db/migrate/20120804122700_add_stripe_invoice_id_to_invoices.rb
+++ b/db/migrate/20120804122700_add_stripe_invoice_id_to_invoices.rb
@@ -1,0 +1,9 @@
+class AddStripeInvoiceIdToInvoices < ActiveRecord::Migration
+  def change
+    change_table :invoices do |t|
+      t.string :stripe_id
+    end
+
+    add_index :invoices, :stripe_id
+  end
+end

--- a/db/migrate/20120806120400_add_plan_to_subscriptions.rb
+++ b/db/migrate/20120806120400_add_plan_to_subscriptions.rb
@@ -1,0 +1,7 @@
+class AddPlanToSubscriptions < ActiveRecord::Migration
+  def change
+    change_table :subscriptions do |t|
+      t.string :plan
+    end
+  end
+end

--- a/db/migrate/20120820164000_rename_plan_on_subscriptions.rb
+++ b/db/migrate/20120820164000_rename_plan_on_subscriptions.rb
@@ -1,0 +1,7 @@
+class RenamePlanOnSubscriptions < ActiveRecord::Migration
+  def change
+    change_table :subscriptions do |t|
+      t.rename(:plan, :selected_plan)
+    end
+  end
+end

--- a/db/migrate/20120905093300_create_stripe_events.rb
+++ b/db/migrate/20120905093300_create_stripe_events.rb
@@ -1,0 +1,14 @@
+class CreateStripeEvents < ActiveRecord::Migration
+  def change
+    create_table :stripe_events, id: false do |t|
+      t.timestamps
+      t.text :event_object
+      t.string :id
+      t.string :event_type
+      t.datetime :date
+    end
+
+    add_index :stripe_events, :event_type
+    add_index :stripe_events, :date
+  end
+end

--- a/db/migrate/20120905171300_add_event_id_to_stripe_events.rb
+++ b/db/migrate/20120905171300_add_event_id_to_stripe_events.rb
@@ -1,0 +1,8 @@
+class AddEventIdToStripeEvents < ActiveRecord::Migration
+  def change
+    change_table :stripe_events do |t|
+      t.string :event_id
+    end
+    add_index :stripe_events, :event_id
+  end
+end

--- a/db/migrate/20120913143800_add_subscriptions_coupon.rb
+++ b/db/migrate/20120913143800_add_subscriptions_coupon.rb
@@ -1,0 +1,7 @@
+class AddSubscriptionsCoupon < ActiveRecord::Migration
+  def change
+    change_table :subscriptions do |t|
+      t.string :coupon
+    end
+  end
+end

--- a/db/migrate/20130306154311_create_pgcrypto_extension.rb
+++ b/db/migrate/20130306154311_create_pgcrypto_extension.rb
@@ -1,0 +1,9 @@
+class CreatePgcryptoExtension < ActiveRecord::Migration
+  def up
+    execute "create extension if not exists pgcrypto"
+  end
+
+  def down
+    execute "drop extension pgcrypto"
+  end
+end

--- a/db/migrate/20130618084205_add_coupons.rb
+++ b/db/migrate/20130618084205_add_coupons.rb
@@ -1,0 +1,18 @@
+class AddCoupons < ActiveRecord::Migration
+  def up
+    create_table :coupons do |t|
+      t.integer :percent_off
+      t.string :coupon_id
+      t.datetime :redeem_by
+      t.integer :amount_off
+      t.string :duration
+      t.integer :duration_in_months
+      t.integer :max_redemptions
+      t.integer :redemptions
+    end
+  end
+
+  def down
+    drop_table :coupons
+  end
+end

--- a/db/migrate/20130701175200_add_contact_id_to_subscriptions.rb
+++ b/db/migrate/20130701175200_add_contact_id_to_subscriptions.rb
@@ -1,0 +1,7 @@
+class AddContactIdToSubscriptions < ActiveRecord::Migration
+  def change
+    change_table :subscriptions do |t|
+      t.belongs_to :contact
+    end
+  end
+end

--- a/db/migrate/20150609175200_add_cancelation_columns_to_subscriptions.rb
+++ b/db/migrate/20150609175200_add_cancelation_columns_to_subscriptions.rb
@@ -1,0 +1,8 @@
+class AddCancelationColumnsToSubscriptions < ActiveRecord::Migration
+  def change
+    change_table :subscriptions do |t|
+      t.datetime :canceled_at
+      t.integer :canceled_by_id
+    end
+  end
+end

--- a/db/migrate/20150615103059_add_status_to_subscriptions.rb
+++ b/db/migrate/20150615103059_add_status_to_subscriptions.rb
@@ -1,0 +1,5 @@
+class AddStatusToSubscriptions < ActiveRecord::Migration
+  def change
+    add_column :subscriptions, :status, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -397,10 +397,10 @@ ALTER SEQUENCE commits_id_seq OWNED BY commits.id;
 CREATE TABLE coupons (
     id integer NOT NULL,
     percent_off integer,
-    coupon_id character varying,
+    coupon_id character varying(255),
     redeem_by timestamp without time zone,
     amount_off integer,
-    duration character varying,
+    duration character varying(255),
     duration_in_months integer,
     max_redemptions integer,
     redemptions integer
@@ -498,11 +498,11 @@ ALTER SEQUENCE emails_id_seq OWNED BY emails.id;
 CREATE TABLE invoices (
     id integer NOT NULL,
     object text,
-    created_at timestamp without time zone,
-    updated_at timestamp without time zone,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL,
     subscription_id integer,
-    invoice_id character varying,
-    stripe_id character varying
+    invoice_id character varying(255),
+    stripe_id character varying(255)
 );
 
 
@@ -756,13 +756,13 @@ ALTER SEQUENCE permissions_id_seq OWNED BY permissions.id;
 
 CREATE TABLE plans (
     id integer NOT NULL,
-    name character varying,
-    coupon character varying,
+    name character varying(255),
+    coupon character varying(255),
     subscription_id integer,
     valid_from timestamp without time zone,
     valid_to timestamp without time zone,
-    created_at timestamp without time zone,
-    updated_at timestamp without time zone,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL,
     amount integer
 );
 
@@ -965,14 +965,33 @@ ALTER SEQUENCE stars_id_seq OWNED BY stars.id;
 --
 
 CREATE TABLE stripe_events (
-    created_at timestamp without time zone,
-    updated_at timestamp without time zone,
+    id integer NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL,
     event_object text,
-    id character varying,
-    event_type character varying,
+    event_type character varying(255),
     date timestamp without time zone,
-    event_id character varying
+    event_id character varying(255)
 );
+
+
+--
+-- Name: stripe_events_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE stripe_events_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: stripe_events_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE stripe_events_id_seq OWNED BY stripe_events.id;
 
 
 --
@@ -981,33 +1000,33 @@ CREATE TABLE stripe_events (
 
 CREATE TABLE subscriptions (
     id integer NOT NULL,
-    cc_token character varying,
+    cc_token character varying(255),
     valid_to timestamp without time zone,
     owner_id integer,
-    owner_type character varying,
-    first_name character varying,
-    last_name character varying,
-    company character varying,
-    zip_code character varying,
-    address character varying,
-    address2 character varying,
-    city character varying,
-    state character varying,
-    country character varying,
-    vat_id character varying,
-    customer_id character varying,
-    created_at timestamp without time zone,
-    updated_at timestamp without time zone,
-    cc_owner character varying,
-    cc_last_digits character varying,
-    cc_expiration_date character varying,
-    billing_email character varying,
-    selected_plan character varying,
-    coupon character varying,
+    owner_type character varying(255),
+    first_name character varying(255),
+    last_name character varying(255),
+    company character varying(255),
+    zip_code character varying(255),
+    address character varying(255),
+    address2 character varying(255),
+    city character varying(255),
+    state character varying(255),
+    country character varying(255),
+    vat_id character varying(255),
+    customer_id character varying(255),
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL,
+    cc_owner character varying(255),
+    cc_last_digits character varying(255),
+    cc_expiration_date character varying(255),
+    billing_email character varying(255),
+    selected_plan character varying(255),
+    coupon character varying(255),
     contact_id integer,
     canceled_at timestamp without time zone,
     canceled_by_id integer,
-    status character varying
+    status character varying(255)
 );
 
 
@@ -1274,6 +1293,13 @@ ALTER TABLE ONLY stars ALTER COLUMN id SET DEFAULT nextval('stars_id_seq'::regcl
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
+ALTER TABLE ONLY stripe_events ALTER COLUMN id SET DEFAULT nextval('stripe_events_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY subscriptions ALTER COLUMN id SET DEFAULT nextval('subscriptions_id_seq'::regclass);
 
 
@@ -1464,6 +1490,14 @@ ALTER TABLE ONLY ssl_keys
 
 ALTER TABLE ONLY stars
     ADD CONSTRAINT stars_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: stripe_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY stripe_events
+    ADD CONSTRAINT stripe_events_pkey PRIMARY KEY (id);
 
 
 --

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -37,6 +37,20 @@ CREATE EXTENSION IF NOT EXISTS pg_trgm WITH SCHEMA public;
 COMMENT ON EXTENSION pg_trgm IS 'text similarity measurement and index searching based on trigrams';
 
 
+--
+-- Name: pgcrypto; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public;
+
+
+--
+-- Name: EXTENSION pgcrypto; Type: COMMENT; Schema: -; Owner: -
+--
+
+COMMENT ON EXTENSION pgcrypto IS 'cryptographic functions';
+
+
 SET search_path = public, pg_catalog;
 
 --
@@ -377,6 +391,42 @@ ALTER SEQUENCE commits_id_seq OWNED BY commits.id;
 
 
 --
+-- Name: coupons; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE coupons (
+    id integer NOT NULL,
+    percent_off integer,
+    coupon_id character varying,
+    redeem_by timestamp without time zone,
+    amount_off integer,
+    duration character varying,
+    duration_in_months integer,
+    max_redemptions integer,
+    redemptions integer
+);
+
+
+--
+-- Name: coupons_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE coupons_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: coupons_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE coupons_id_seq OWNED BY coupons.id;
+
+
+--
 -- Name: crons; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -439,6 +489,40 @@ CREATE SEQUENCE emails_id_seq
 --
 
 ALTER SEQUENCE emails_id_seq OWNED BY emails.id;
+
+
+--
+-- Name: invoices; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE invoices (
+    id integer NOT NULL,
+    object text,
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone,
+    subscription_id integer,
+    invoice_id character varying,
+    stripe_id character varying
+);
+
+
+--
+-- Name: invoices_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE invoices_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: invoices_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE invoices_id_seq OWNED BY invoices.id;
 
 
 --
@@ -667,6 +751,42 @@ ALTER SEQUENCE permissions_id_seq OWNED BY permissions.id;
 
 
 --
+-- Name: plans; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE plans (
+    id integer NOT NULL,
+    name character varying,
+    coupon character varying,
+    subscription_id integer,
+    valid_from timestamp without time zone,
+    valid_to timestamp without time zone,
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone,
+    amount integer
+);
+
+
+--
+-- Name: plans_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE plans_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: plans_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE plans_id_seq OWNED BY plans.id;
+
+
+--
 -- Name: repositories; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -841,6 +961,76 @@ ALTER SEQUENCE stars_id_seq OWNED BY stars.id;
 
 
 --
+-- Name: stripe_events; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE stripe_events (
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone,
+    event_object text,
+    id character varying,
+    event_type character varying,
+    date timestamp without time zone,
+    event_id character varying
+);
+
+
+--
+-- Name: subscriptions; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE subscriptions (
+    id integer NOT NULL,
+    cc_token character varying,
+    valid_to timestamp without time zone,
+    owner_id integer,
+    owner_type character varying,
+    first_name character varying,
+    last_name character varying,
+    company character varying,
+    zip_code character varying,
+    address character varying,
+    address2 character varying,
+    city character varying,
+    state character varying,
+    country character varying,
+    vat_id character varying,
+    customer_id character varying,
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone,
+    cc_owner character varying,
+    cc_last_digits character varying,
+    cc_expiration_date character varying,
+    billing_email character varying,
+    selected_plan character varying,
+    coupon character varying,
+    contact_id integer,
+    canceled_at timestamp without time zone,
+    canceled_by_id integer,
+    status character varying
+);
+
+
+--
+-- Name: subscriptions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE subscriptions_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: subscriptions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE subscriptions_id_seq OWNED BY subscriptions.id;
+
+
+--
 -- Name: tokens; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -986,6 +1176,13 @@ ALTER TABLE ONLY commits ALTER COLUMN id SET DEFAULT nextval('commits_id_seq'::r
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
+ALTER TABLE ONLY coupons ALTER COLUMN id SET DEFAULT nextval('coupons_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY crons ALTER COLUMN id SET DEFAULT nextval('crons_id_seq'::regclass);
 
 
@@ -994,6 +1191,13 @@ ALTER TABLE ONLY crons ALTER COLUMN id SET DEFAULT nextval('crons_id_seq'::regcl
 --
 
 ALTER TABLE ONLY emails ALTER COLUMN id SET DEFAULT nextval('emails_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY invoices ALTER COLUMN id SET DEFAULT nextval('invoices_id_seq'::regclass);
 
 
 --
@@ -1035,6 +1239,13 @@ ALTER TABLE ONLY permissions ALTER COLUMN id SET DEFAULT nextval('permissions_id
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
+ALTER TABLE ONLY plans ALTER COLUMN id SET DEFAULT nextval('plans_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY repositories ALTER COLUMN id SET DEFAULT nextval('repositories_id_seq'::regclass);
 
 
@@ -1057,6 +1268,13 @@ ALTER TABLE ONLY ssl_keys ALTER COLUMN id SET DEFAULT nextval('ssl_keys_id_seq':
 --
 
 ALTER TABLE ONLY stars ALTER COLUMN id SET DEFAULT nextval('stars_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY subscriptions ALTER COLUMN id SET DEFAULT nextval('subscriptions_id_seq'::regclass);
 
 
 --
@@ -1129,6 +1347,14 @@ ALTER TABLE ONLY commits
 
 
 --
+-- Name: coupons_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY coupons
+    ADD CONSTRAINT coupons_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: crons_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -1142,6 +1368,14 @@ ALTER TABLE ONLY crons
 
 ALTER TABLE ONLY emails
     ADD CONSTRAINT emails_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: invoices_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY invoices
+    ADD CONSTRAINT invoices_pkey PRIMARY KEY (id);
 
 
 --
@@ -1193,6 +1427,14 @@ ALTER TABLE ONLY permissions
 
 
 --
+-- Name: plans_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY plans
+    ADD CONSTRAINT plans_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: repositories_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -1222,6 +1464,14 @@ ALTER TABLE ONLY ssl_keys
 
 ALTER TABLE ONLY stars
     ADD CONSTRAINT stars_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: subscriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY subscriptions
+    ADD CONSTRAINT subscriptions_pkey PRIMARY KEY (id);
 
 
 --
@@ -1344,6 +1594,13 @@ CREATE INDEX index_emails_on_email ON emails USING btree (email);
 --
 
 CREATE INDEX index_emails_on_user_id ON emails USING btree (user_id);
+
+
+--
+-- Name: index_invoices_on_stripe_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_invoices_on_stripe_id ON invoices USING btree (stripe_id);
 
 
 --
@@ -1599,6 +1856,27 @@ CREATE UNIQUE INDEX index_stars_on_user_id_and_repository_id ON stars USING btre
 
 
 --
+-- Name: index_stripe_events_on_date; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_stripe_events_on_date ON stripe_events USING btree (date);
+
+
+--
+-- Name: index_stripe_events_on_event_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_stripe_events_on_event_id ON stripe_events USING btree (event_id);
+
+
+--
+-- Name: index_stripe_events_on_event_type; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_stripe_events_on_event_type ON stripe_events USING btree (event_type);
+
+
+--
 -- Name: index_tokens_on_token; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -1785,23 +2063,47 @@ INSERT INTO schema_migrations (version) VALUES ('20120521174400');
 
 INSERT INTO schema_migrations (version) VALUES ('20120527235800');
 
+INSERT INTO schema_migrations (version) VALUES ('20120702111126');
+
+INSERT INTO schema_migrations (version) VALUES ('20120703114226');
+
 INSERT INTO schema_migrations (version) VALUES ('20120713140816');
 
 INSERT INTO schema_migrations (version) VALUES ('20120713153215');
 
 INSERT INTO schema_migrations (version) VALUES ('20120725005300');
 
+INSERT INTO schema_migrations (version) VALUES ('201207261749');
+
 INSERT INTO schema_migrations (version) VALUES ('20120727151900');
 
 INSERT INTO schema_migrations (version) VALUES ('20120731005301');
 
+INSERT INTO schema_migrations (version) VALUES ('20120731074000');
+
 INSERT INTO schema_migrations (version) VALUES ('20120802001001');
+
+INSERT INTO schema_migrations (version) VALUES ('20120803164000');
+
+INSERT INTO schema_migrations (version) VALUES ('20120803182300');
+
+INSERT INTO schema_migrations (version) VALUES ('20120804122700');
+
+INSERT INTO schema_migrations (version) VALUES ('20120806120400');
+
+INSERT INTO schema_migrations (version) VALUES ('20120820164000');
+
+INSERT INTO schema_migrations (version) VALUES ('20120905093300');
+
+INSERT INTO schema_migrations (version) VALUES ('20120905171300');
 
 INSERT INTO schema_migrations (version) VALUES ('20120911160000');
 
 INSERT INTO schema_migrations (version) VALUES ('20120911230000');
 
 INSERT INTO schema_migrations (version) VALUES ('20120911230001');
+
+INSERT INTO schema_migrations (version) VALUES ('20120913143800');
 
 INSERT INTO schema_migrations (version) VALUES ('20120915012000');
 
@@ -1859,6 +2161,8 @@ INSERT INTO schema_migrations (version) VALUES ('20130208135801');
 
 INSERT INTO schema_migrations (version) VALUES ('20130208215252');
 
+INSERT INTO schema_migrations (version) VALUES ('20130306154311');
+
 INSERT INTO schema_migrations (version) VALUES ('20130311211101');
 
 INSERT INTO schema_migrations (version) VALUES ('20130327100801');
@@ -1881,6 +2185,8 @@ INSERT INTO schema_migrations (version) VALUES ('20130521134800');
 
 INSERT INTO schema_migrations (version) VALUES ('20130521141357');
 
+INSERT INTO schema_migrations (version) VALUES ('20130618084205');
+
 INSERT INTO schema_migrations (version) VALUES ('20130629122945');
 
 INSERT INTO schema_migrations (version) VALUES ('20130629133531');
@@ -1888,6 +2194,8 @@ INSERT INTO schema_migrations (version) VALUES ('20130629133531');
 INSERT INTO schema_migrations (version) VALUES ('20130629174449');
 
 INSERT INTO schema_migrations (version) VALUES ('20130701123456');
+
+INSERT INTO schema_migrations (version) VALUES ('20130701175200');
 
 INSERT INTO schema_migrations (version) VALUES ('20130702123456');
 
@@ -1981,6 +2289,8 @@ INSERT INTO schema_migrations (version) VALUES ('20150528101610');
 
 INSERT INTO schema_migrations (version) VALUES ('20150528101611');
 
+INSERT INTO schema_migrations (version) VALUES ('20150609175200');
+
 INSERT INTO schema_migrations (version) VALUES ('20150610143500');
 
 INSERT INTO schema_migrations (version) VALUES ('20150610143501');
@@ -2002,6 +2312,8 @@ INSERT INTO schema_migrations (version) VALUES ('20150610143508');
 INSERT INTO schema_migrations (version) VALUES ('20150610143509');
 
 INSERT INTO schema_migrations (version) VALUES ('20150610143510');
+
+INSERT INTO schema_migrations (version) VALUES ('20150615103059');
 
 INSERT INTO schema_migrations (version) VALUES ('20150629231300');
 

--- a/lib/travis/migrations/version.rb
+++ b/lib/travis/migrations/version.rb
@@ -1,5 +1,5 @@
 module Travis
   module Migrations
-    VERSION = "0.0.2"
+    VERSION = "0.0.3"
   end
 end

--- a/spec/travis_migrations_spec.rb
+++ b/spec/travis_migrations_spec.rb
@@ -1,21 +1,37 @@
 require 'spec_helper'
 require 'yaml'
 
-describe "Travis Migrations Custom Rake Tasks" do
-  it "setups the database with the correct tables" do
-    dbconfig = YAML.load(ERB.new(File.read('config/database.yml')).result)
-    ActiveRecord::Base.establish_connection dbconfig['test']
-    ActiveRecord::Base.connection_pool.with_connection do |connection|
 
-      tables = connection.execute("SELECT table_name FROM information_schema.tables WHERE table_schema = 'public';").field_values('table_name')
+describe 'Rake tasks' do
+  let(:config) { YAML.load(ERB.new(File.read('config/database.yml')).result) }
+  let(:conn)   { ActiveRecord::Base.connection }
+  let(:tables) { conn.select_values("SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'") }
+  before       { ActiveRecord::Base.establish_connection(config['test']) }
 
-      ["schema_migrations", "tokens", "users", "builds", "repositories",
-        "commits", "requests", "ssl_keys", "memberships", "urls",
-        "permissions", "jobs", "broadcasts", "emails", "logs", "log_parts",
-        "organizations", "annotation_providers", "annotations", "branches",
-        "stars", "crons", "subscriptions", "plans", "coupons", "stripe_events", "invoices"].each do |table_name|
-        expect(tables).to include(table_name)
-      end
+  def run(cmd)
+    system "RAILS_ENV=test bundle exec #{cmd}"
+    expect($?.exitstatus).to eq 0
+  end
+
+  shared_examples_for 'creates the expected tables' do
+    it 'creates the expected tables' do
+      expect(tables.sort).to eq %w(
+        schema_migrations tokens users builds repositories commits requests
+        ssl_keys memberships urls permissions jobs broadcasts emails logs
+        log_parts organizations annotation_providers annotations branches stars
+        crons subscriptions plans coupons stripe_events invoices
+      ).sort
     end
+  end
+
+  describe 'rake db:create' do
+    before { run 'rake db:drop db:create db:migrate' }
+    include_examples 'creates the expected tables'
+
+  end
+
+  describe 'rake db:schema:load' do
+    before { run 'rake db:drop db:create db:structure:load' }
+    include_examples 'creates the expected tables'
   end
 end

--- a/spec/travis_migrations_spec.rb
+++ b/spec/travis_migrations_spec.rb
@@ -13,7 +13,7 @@ describe "Travis Migrations Custom Rake Tasks" do
         "commits", "requests", "ssl_keys", "memberships", "urls",
         "permissions", "jobs", "broadcasts", "emails", "logs", "log_parts",
         "organizations", "annotation_providers", "annotations", "branches",
-        "stars", "crons"].each do |table_name|
+        "stars", "crons", "subscriptions", "plans", "coupons", "stripe_events", "invoices"].each do |table_name|
         expect(tables).to include(table_name)
       end
     end


### PR DESCRIPTION
This adds all the pro-migrations to this repo, so that we only now add migrations to the one repo.

A change has been made to the `config/database.yml` whereby it now fetches a `DATABASE_NAME` ENV variable in order to know what *local* database to run migrations on (or uses a default as defined). This ENV variable can be overridden manually when running migrations via the command line. Details of how to do this have been added to the README.

The spec has also been updated to include the new tables.

Migrations have been tested locally, on travis-ci, and also tested on the `travis-staging` db. The migration ran successfully, adding the following (previously pro) tables. 