### PR TITLE
add avatar_url column to users table

### DIFF
--- a/db/migrate/20161908103700_add_avatar_url_to_users.rb
+++ b/db/migrate/20161908103700_add_avatar_url_to_users.rb
@@ -1,0 +1,9 @@
+class AddAvatarUrlToUsers < ActiveRecord::Migration
+  def up
+    add_column :users, :avatar_url, :string
+  end
+
+  def down
+    remove_column :users, :avatar_url
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1114,7 +1114,8 @@ CREATE TABLE users (
     synced_at timestamp without time zone,
     github_scopes text,
     education boolean,
-    first_logged_in_at timestamp without time zone
+    first_logged_in_at timestamp without time zone,
+    avatar_url character varying
 );
 
 
@@ -2366,4 +2367,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160623133900');
 INSERT INTO schema_migrations (version) VALUES ('20160623133901');
 
 INSERT INTO schema_migrations (version) VALUES ('20160712125400');
+
+INSERT INTO schema_migrations (version) VALUES ('20161908103700');
 


### PR DESCRIPTION
This adds an avatar_url column to the users table so that we can use a users avatar_url if they have one.
The migration has been run on staging successfully.
https://github.com/travis-pro/team-teal/issues/1288