### PR TITLE
Remove unused `type` indexes

### DIFF
--- a/db/migrate/20161028154600_remove_type_indices.rb
+++ b/db/migrate/20161028154600_remove_type_indices.rb
@@ -1,0 +1,14 @@
+class RemoveTypeIndices < ActiveRecord::Migration
+  self.disable_ddl_transaction!
+
+  def up
+    execute "DROP INDEX CONCURRENTLY IF EXISTS index_requests_on_event_type"
+    execute "DROP INDEX CONCURRENTLY IF EXISTS index_jobs_on_owner_type"
+    
+  end
+
+  def down
+    execute "CREATE INDEX CONCURRENTLY index_requests_on_event_type ON requests(event_type)"
+    execute "CREATE INDEX CONCURRENTLY index_jobs_on_owner_type ON jobs(owner_type)"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1426,13 +1426,6 @@ CREATE INDEX index_jobs_on_owner_id ON jobs USING btree (owner_id);
 
 
 --
--- Name: index_jobs_on_owner_type; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_jobs_on_owner_type ON jobs USING btree (owner_type);
-
-
---
 -- Name: index_jobs_on_queue; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -2132,4 +2125,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160712125400');
 INSERT INTO schema_migrations (version) VALUES ('20160819103700');
 
 INSERT INTO schema_migrations (version) VALUES ('20160920220400');
+
+INSERT INTO schema_migrations (version) VALUES ('20161028154600');
 


### PR DESCRIPTION
This migration removes `index_jobs_on_owner_type` and `index_requests_on_event_type`.

Heroku doesn't use these indexes. 

The migrations have been deployed to both .org and .com staging DBs. There don't seem to be any issues on travis-ci staging, nor in admin staging apps...