### PR TITLE
add builds index repository id and number

### DIFF
--- a/db/main/migrate/20161221171300_builds_add_index_repository_id_and_number.rb
+++ b/db/main/migrate/20161221171300_builds_add_index_repository_id_and_number.rb
@@ -1,0 +1,11 @@
+class BuildsAddIndexRepositoryIdAndNumber < ActiveRecord::Migration
+  self.disable_ddl_transaction!
+
+  def up
+    execute "CREATE INDEX CONCURRENTLY index_builds_on_repository_id_and_number ON builds(repository_id, (number::integer))"
+  end
+
+  def down
+    execute "DROP INDEX CONCURRENTLY index_builds_on_repository_id_and_number"
+  end
+end

--- a/db/main/structure.sql
+++ b/db/main/structure.sql
@@ -1365,6 +1365,13 @@ CREATE INDEX index_builds_on_repository_id ON builds USING btree (repository_id)
 
 
 --
+-- Name: index_builds_on_repository_id_and_number; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_builds_on_repository_id_and_number ON builds USING btree (repository_id, ((number)::integer));
+
+
+--
 -- Name: index_builds_on_repository_id_and_number_and_event_type; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -2135,4 +2142,6 @@ INSERT INTO schema_migrations (version) VALUES ('20161101000000');
 INSERT INTO schema_migrations (version) VALUES ('20161101000001');
 
 INSERT INTO schema_migrations (version) VALUES ('20161202000000');
+
+INSERT INTO schema_migrations (version) VALUES ('20161221171300');
 


### PR DESCRIPTION
this adds an index to address a problem with build histories taking a long time to load when a repo has many thousands of builds.

I've run it locally and it adds the exact same index that was created on the .com production DB to test with:

`"index_builds_on_repository_id_and_number" btree (repository_id, (number::integer))`