### PR TITLE
Add matrix to run specs on Postgres versions 9.3 and 9.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ services:
   - postgresql
 
 addons:
-  postgresql: "9.3"
+  postgresql: 
+    - 9.3
+    - 9.6
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,6 @@ sudo: false
 services:
   - postgresql
 
-addons:
-  postgresql: "9.3"
-  postgresql: "9.6"
-
 cache:
   directories:
     - vendor/bundle
@@ -20,6 +16,9 @@ env:
 
 matrix:
   fast_finish: true
+  postgresql:
+    - 9.3
+    - 9.6
 
 before_install:
   - gem install bundler -v 1.12.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,10 @@ env:
 matrix:
   matrix:
   include:
-    - rvm: 2.3.3
+    - rvm: 2.3.4
       addons:
         postgresql: "9.3"
-    - rvm: 2.3.3
+    - rvm: 2.3.4
       addons:
         postgresql: "9.6"
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,15 @@ env:
   - RAILS_ENV=test
 
 matrix:
+  matrix:
+  include:
+    - rvm: 2.3.3
+      addons:
+        postgresql: "9.3"
+    - rvm: 2.3.3
+      addons:
+        postgresql: "9.6"
   fast_finish: true
-  postgresql:
-    - 9.3
-    - 9.6
 
 before_install:
   - gem install bundler -v 1.12.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,13 +15,12 @@ env:
   - RAILS_ENV=test
 
 matrix:
-  matrix:
-  include:
-    - addons:
-        postgresql: "9.3"
-    - addons:
-        postgresql: "9.6"
-  fast_finish: true
+include:
+  - addons:
+      postgresql: "9.3"
+  - addons:
+      postgresql: "9.6"
+fast_finish: true
 
 before_install:
   - gem install bundler -v 1.12.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,9 @@ env:
 matrix:
   matrix:
   include:
-    - rvm: 2.3.4
-      addons:
+    - addons:
         postgresql: "9.3"
-    - rvm: 2.3.4
-      addons:
+    - addons:
         postgresql: "9.6"
   fast_finish: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,8 @@ services:
   - postgresql
 
 addons:
-  postgresql: 
-    - 9.3
-    - 9.6
+  postgresql: "9.3"
+  postgresql: "9.6"
 
 cache:
   directories:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Any changes to this document should also be reflected in the [Travis Builders Ma
 
 In short, migrations should be run locally while standing in this repository during development. For tests (e.g. via `.travis.yml`) applications should contain their own tooling that loads the schema (e.g. see [travis-hub](https://github.com/travis-ci/travis-hub/blob/master/Rakefile#L12)).
 
-Please use Postgresql 9.4 for local development and testing.
+Please use Postgresql 9.4 for local development and testing, but note that production and enterprise environments require compatibility with both 9.3 and 9.6.
 
 Installing
 ----------


### PR DESCRIPTION
Our staging DBs have been upgraded to postgresql 9.6 and our production DBs will be upgraded soon. 

However, Enterprise won't be updated for a while so we need to ensure migrations will be backwards compatible with the version it uses, 9.3.

This PR adds a matrix that runs two separate jobs, one using postgres 9.3, one using postgres 9.6 thus ensuring any migrations will be compatible with both.