### PR TITLE
Add set_updated_at triggers to jobs and builds

### DIFF
--- a/db/main/migrate/20171025000000_add_updated_at_trigger_to_builds_and_jobs.rb
+++ b/db/main/migrate/20171025000000_add_updated_at_trigger_to_builds_and_jobs.rb
@@ -11,28 +11,14 @@ class AddUpdatedAtTriggerToBuildsAndJobs < ActiveRecord::Migration
       END;
       $$ LANGUAGE plpgsql;
 
-      CREATE TRIGGER set_updated_at_on_builds_update
-      BEFORE UPDATE ON builds
+      CREATE TRIGGER set_updated_at_on_builds
+      BEFORE INSERT OR UPDATE ON builds
       FOR EACH ROW
-      WHEN (OLD.updated_at = NEW.updated_at)
       EXECUTE PROCEDURE set_updated_at();
 
-      CREATE TRIGGER set_updated_at_on_builds_insert
-      BEFORE INSERT on builds
+      CREATE TRIGGER set_updated_at_on_jobs
+      BEFORE INSERT OR UPDATE ON jobs
       FOR EACH ROW
-      WHEN (NEW.updated_at IS NULL)
-      EXECUTE PROCEDURE set_updated_at();
-
-      CREATE TRIGGER set_updated_at_on_jobs_update
-      BEFORE UPDATE ON jobs
-      FOR EACH ROW
-      WHEN (OLD.updated_at = NEW.updated_at)
-      EXECUTE PROCEDURE set_updated_at();
-
-      CREATE TRIGGER set_updated_at_on_jobs_insert
-      BEFORE INSERT on jobs
-      FOR EACH ROW
-      WHEN (NEW.updated_at IS NULL)
       EXECUTE PROCEDURE set_updated_at();
     SQL
   end

--- a/db/main/migrate/20171025000000_add_updated_at_trigger_to_builds_and_jobs.rb
+++ b/db/main/migrate/20171025000000_add_updated_at_trigger_to_builds_and_jobs.rb
@@ -1,0 +1,52 @@
+class AddUpdatedAtTriggerToBuildsAndJobs < ActiveRecord::Migration
+  def up
+    execute <<-SQL
+      CREATE FUNCTION set_updated_at() RETURNS trigger AS $$
+      BEGIN
+        IF TG_OP = 'INSERT' OR
+             (TG_OP = 'UPDATE' AND NEW.* IS DISTINCT FROM OLD.*) THEN
+          NEW.updated_at := now();
+        END IF;
+        RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql;
+
+      CREATE TRIGGER set_updated_at_on_builds_update
+      BEFORE UPDATE ON builds
+      FOR EACH ROW
+      WHEN (OLD.updated_at = NEW.updated_at)
+      EXECUTE PROCEDURE set_updated_at();
+
+      CREATE TRIGGER set_updated_at_on_builds_insert
+      BEFORE INSERT on builds
+      FOR EACH ROW
+      WHEN (NEW.updated_at IS NULL)
+      EXECUTE PROCEDURE set_updated_at();
+
+      CREATE TRIGGER set_updated_at_on_jobs_update
+      BEFORE UPDATE ON jobs
+      FOR EACH ROW
+      WHEN (OLD.updated_at = NEW.updated_at)
+      EXECUTE PROCEDURE set_updated_at();
+
+      CREATE TRIGGER set_updated_at_on_jobs_insert
+      BEFORE INSERT on jobs
+      FOR EACH ROW
+      WHEN (NEW.updated_at IS NULL)
+      EXECUTE PROCEDURE set_updated_at();
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      DROP TRIGGER IF EXISTS set_updated_at_on_builds_update on builds;
+      DROP TRIGGER IF EXISTS set_updated_at_on_builds_insert on builds;
+
+      DROP TRIGGER IF EXISTS set_updated_at_on_jobs_update on jobs;
+      DROP TRIGGER IF EXISTS set_updated_at_on_jobs_insert on jobs;
+
+      DROP FUNCTION IF EXISTS set_updated_at();
+    SQL
+  end
+end
+

--- a/db/main/structure.sql
+++ b/db/main/structure.sql
@@ -92,6 +92,41 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
+-- Name: abuses; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE abuses (
+    id integer NOT NULL,
+    owner_id integer,
+    owner_type character varying,
+    request_id integer,
+    level integer NOT NULL,
+    reason character varying NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: abuses_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE abuses_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: abuses_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE abuses_id_seq OWNED BY abuses.id;
+
+
+--
 -- Name: annotation_providers; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1353,6 +1388,13 @@ ALTER SEQUENCE users_id_seq OWNED BY users.id;
 
 
 --
+-- Name: abuses id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY abuses ALTER COLUMN id SET DEFAULT nextval('abuses_id_seq'::regclass);
+
+
+--
 -- Name: annotation_providers id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1567,6 +1609,14 @@ ALTER TABLE ONLY user_beta_features ALTER COLUMN id SET DEFAULT nextval('user_be
 --
 
 ALTER TABLE ONLY users ALTER COLUMN id SET DEFAULT nextval('users_id_seq'::regclass);
+
+
+--
+-- Name: abuses abuses_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY abuses
+    ADD CONSTRAINT abuses_pkey PRIMARY KEY (id);
 
 
 --
@@ -1831,6 +1881,20 @@ ALTER TABLE ONLY user_beta_features
 
 ALTER TABLE ONLY users
     ADD CONSTRAINT users_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: index_abuses_on_owner; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_abuses_on_owner ON abuses USING btree (owner_id);
+
+
+--
+-- Name: index_abuses_on_owner_id_and_owner_type_and_level; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_abuses_on_owner_id_and_owner_type_and_level ON abuses USING btree (owner_id, owner_type, level);
 
 
 --
@@ -2825,5 +2889,9 @@ INSERT INTO schema_migrations (version) VALUES ('20170911172800');
 
 INSERT INTO schema_migrations (version) VALUES ('20171017104500');
 
+INSERT INTO schema_migrations (version) VALUES ('20171024000000');
+
 INSERT INTO schema_migrations (version) VALUES ('20171025000000');
+
+INSERT INTO schema_migrations (version) VALUES ('20171103000000');
 

--- a/db/main/structure.sql
+++ b/db/main/structure.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.5.8
--- Dumped by pg_dump version 10.0
+-- Dumped from database version 9.6.5
+-- Dumped by pg_dump version 9.6.5
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -70,44 +70,26 @@ CREATE TYPE source_type AS ENUM (
 );
 
 
+--
+-- Name: set_updated_at(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION set_updated_at() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+      BEGIN
+        IF TG_OP = 'INSERT' OR
+             (TG_OP = 'UPDATE' AND NEW.* IS DISTINCT FROM OLD.*) THEN
+          NEW.updated_at := now();
+        END IF;
+        RETURN NEW;
+      END;
+      $$;
+
+
 SET default_tablespace = '';
 
 SET default_with_oids = false;
-
---
--- Name: abuses; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE abuses (
-    id integer NOT NULL,
-    owner_id integer,
-    owner_type character varying,
-    request_id integer,
-    level integer NOT NULL,
-    reason character varying NOT NULL,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
-);
-
-
---
--- Name: abuses_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE abuses_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: abuses_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE abuses_id_seq OWNED BY abuses.id;
-
 
 --
 -- Name: annotation_providers; Type: TABLE; Schema: public; Owner: -
@@ -1371,13 +1353,6 @@ ALTER SEQUENCE users_id_seq OWNED BY users.id;
 
 
 --
--- Name: abuses id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY abuses ALTER COLUMN id SET DEFAULT nextval('abuses_id_seq'::regclass);
-
-
---
 -- Name: annotation_providers id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1592,14 +1567,6 @@ ALTER TABLE ONLY user_beta_features ALTER COLUMN id SET DEFAULT nextval('user_be
 --
 
 ALTER TABLE ONLY users ALTER COLUMN id SET DEFAULT nextval('users_id_seq'::regclass);
-
-
---
--- Name: abuses abuses_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY abuses
-    ADD CONSTRAINT abuses_pkey PRIMARY KEY (id);
 
 
 --
@@ -1864,13 +1831,6 @@ ALTER TABLE ONLY user_beta_features
 
 ALTER TABLE ONLY users
     ADD CONSTRAINT users_pkey PRIMARY KEY (id);
-
-
---
--- Name: index_abuses_on_owner_id_and_owner_type_and_level; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX index_abuses_on_owner_id_and_owner_type_and_level ON abuses USING btree (owner_id, owner_type, level);
 
 
 --
@@ -2333,6 +2293,20 @@ CREATE UNIQUE INDEX subscriptions_owner ON subscriptions USING btree (owner_id, 
 --
 
 CREATE UNIQUE INDEX unique_schema_migrations ON schema_migrations USING btree (version);
+
+
+--
+-- Name: builds set_updated_at_on_builds; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER set_updated_at_on_builds BEFORE INSERT OR UPDATE ON builds FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
+
+
+--
+-- Name: jobs set_updated_at_on_jobs; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER set_updated_at_on_jobs BEFORE INSERT OR UPDATE ON jobs FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
 
 
 --
@@ -2851,7 +2825,5 @@ INSERT INTO schema_migrations (version) VALUES ('20170911172800');
 
 INSERT INTO schema_migrations (version) VALUES ('20171017104500');
 
-INSERT INTO schema_migrations (version) VALUES ('20171024000000');
-
-INSERT INTO schema_migrations (version) VALUES ('20171103000000');
+INSERT INTO schema_migrations (version) VALUES ('20171025000000');
 

--- a/spec/set_updated_at_trigger_spec.rb
+++ b/spec/set_updated_at_trigger_spec.rb
@@ -1,0 +1,132 @@
+require 'spec_helper'
+require 'yaml'
+
+describe 'set_updated_at trigger' do
+  def run(cmd)
+    system "RAILS_ENV=test bundle exec #{cmd}"
+    expect($?.exitstatus).to eq 0
+  end
+
+  let(:config) { YAML.load(ERB.new(File.read('config/database.yml')).result) }
+  before(:all) do
+    run 'rake db:drop db:create db:migrate'
+  end
+  before do
+    ActiveRecord::Base.establish_connection(config['test'])
+    conn.execute('TRUNCATE builds CASCADE;')
+    conn.execute('TRUNCATE jobs CASCADE;')
+  end
+  after do
+    ActiveRecord::Base.remove_connection
+  end
+  let(:conn)   { ActiveRecord::Base.connection }
+
+  def e(query)
+    conn.execute(query)
+  end
+
+  def s(query)
+    conn.select_one(query)
+  end
+
+  describe 'jobs' do
+    it 'sets updated_at on INSERT' do
+      e "INSERT INTO jobs (number, created_at) VALUES ('10.1', now());"
+      result = s "SELECT id, updated_at FROM jobs"
+      expect(result['updated_at']).to_not be_nil
+    end
+
+    it 'sets updated_at on UPDATE' do
+      e "INSERT INTO jobs (number, created_at) VALUES ('10.1', now());"
+      after_insert = s "SELECT id, updated_at FROM jobs"
+      e "UPDATE jobs SET number = '11.1';"
+      after_update = s "SELECT id, updated_at FROM jobs"
+
+      expect(after_insert['id']).to eql(after_update['id'])
+      expect(after_insert['updated_at']).to_not eql(after_update['updated_at'])
+
+      # now update without any changes, trigger should not fire
+      e "UPDATE jobs SET number = '11.1';"
+      after_2nd_update = s "SELECT id, updated_at FROM jobs"
+
+      expect(after_2nd_update['id']).to eql(after_update['id'])
+      expect(after_2nd_update['updated_at']).to eql(after_update['updated_at'])
+    end
+
+    it 'does not set updated_at if it is already passed' do
+      e "INSERT INTO jobs (number, created_at, updated_at) VALUES ('10.1', now(), TIMESTAMP '2000-01-01 12:00:00');"
+      after_insert = s "SELECT id, to_char(updated_at, 'YYYY-MM-DD HH24:MI:SS') as updated_at FROM jobs"
+
+      expect(after_insert['updated_at']).to eql("2000-01-01 12:00:00")
+
+      e "UPDATE jobs SET number = '11.1', updated_at = TIMESTAMP '2001-01-01 12:00:00';"
+      after_update = s "SELECT id, to_char(updated_at, 'YYYY-MM-DD HH24:MI:SS') as updated_at FROM jobs"
+
+      expect(after_update['updated_at']).to eql("2001-01-01 12:00:00")
+    end
+
+    it 'works also for new columns' do
+      e "INSERT INTO jobs (number, created_at) VALUES ('10.1', now());"
+      after_insert = s "SELECT id, updated_at FROM jobs"
+
+      e "alter table jobs add column foo integer not null default 0;"
+
+      e "UPDATE jobs SET foo = 1;"
+      after_update = s "SELECT id, updated_at FROM jobs"
+
+      expect(after_insert['id']).to eql(after_update['id'])
+      expect(after_insert['updated_at']).to_not eql(after_update['updated_at'])
+    end
+  end
+
+  describe 'builds' do
+    it 'sets updated_at on INSERT' do
+      e "INSERT INTO builds (number, created_at) VALUES ('10', now());"
+      result = s "SELECT id, updated_at FROM builds"
+      expect(result['updated_at']).to_not be_nil
+    end
+
+    it 'sets updated_at on UPDATE' do
+      e "INSERT INTO builds (number, created_at) VALUES ('10', now());"
+      after_insert = s "SELECT id, updated_at FROM builds"
+      e "UPDATE builds SET number = '11';"
+      after_update = s "SELECT id, updated_at FROM builds"
+
+      expect(after_insert['id']).to eql(after_update['id'])
+      expect(after_insert['updated_at']).to_not eql(after_update['updated_at'])
+
+      # now update without any changes, trigger should not fire
+      e "UPDATE builds SET number = '11';"
+      after_2nd_update = s "SELECT id, updated_at FROM builds"
+
+      expect(after_2nd_update['id']).to eql(after_update['id'])
+      expect(after_2nd_update['updated_at']).to eql(after_update['updated_at'])
+    end
+
+    it 'does not set updated_at if it is already passed' do
+      e "INSERT INTO builds (number, created_at, updated_at) VALUES ('10', now(), TIMESTAMP '2000-01-01 12:00:00');"
+      after_insert = s "SELECT id, to_char(updated_at, 'YYYY-MM-DD HH24:MI:SS') as updated_at FROM builds"
+
+      expect(after_insert['updated_at']).to eql("2000-01-01 12:00:00")
+
+      e "UPDATE builds SET number = '11', updated_at = TIMESTAMP '2001-01-01 12:00:00';"
+      after_update = s "SELECT id, to_char(updated_at, 'YYYY-MM-DD HH24:MI:SS') as updated_at FROM builds"
+
+      expect(after_update['updated_at']).to eql("2001-01-01 12:00:00")
+    end
+
+    it 'works also for new columns' do
+      e "INSERT INTO builds (number, created_at) VALUES (10, now());"
+      after_insert = s "SELECT id, updated_at FROM builds"
+
+      e "alter table builds add column foo integer not null default 0;"
+
+      e "UPDATE builds SET foo = 1;"
+      after_update = s "SELECT id, updated_at FROM builds"
+
+      expect(after_insert['id']).to eql(after_update['id'])
+      expect(after_insert['updated_at']).to_not eql(after_update['updated_at'])
+    end
+
+  end
+end

--- a/spec/set_updated_at_trigger_spec.rb
+++ b/spec/set_updated_at_trigger_spec.rb
@@ -53,18 +53,6 @@ describe 'set_updated_at trigger' do
       expect(after_2nd_update['updated_at']).to eql(after_update['updated_at'])
     end
 
-    it 'does not set updated_at if it is already passed' do
-      e "INSERT INTO jobs (number, created_at, updated_at) VALUES ('10.1', now(), TIMESTAMP '2000-01-01 12:00:00');"
-      after_insert = s "SELECT id, to_char(updated_at, 'YYYY-MM-DD HH24:MI:SS') as updated_at FROM jobs"
-
-      expect(after_insert['updated_at']).to eql("2000-01-01 12:00:00")
-
-      e "UPDATE jobs SET number = '11.1', updated_at = TIMESTAMP '2001-01-01 12:00:00';"
-      after_update = s "SELECT id, to_char(updated_at, 'YYYY-MM-DD HH24:MI:SS') as updated_at FROM jobs"
-
-      expect(after_update['updated_at']).to eql("2001-01-01 12:00:00")
-    end
-
     it 'works also for new columns' do
       e "INSERT INTO jobs (number, created_at) VALUES ('10.1', now());"
       after_insert = s "SELECT id, updated_at FROM jobs"
@@ -101,18 +89,6 @@ describe 'set_updated_at trigger' do
 
       expect(after_2nd_update['id']).to eql(after_update['id'])
       expect(after_2nd_update['updated_at']).to eql(after_update['updated_at'])
-    end
-
-    it 'does not set updated_at if it is already passed' do
-      e "INSERT INTO builds (number, created_at, updated_at) VALUES ('10', now(), TIMESTAMP '2000-01-01 12:00:00');"
-      after_insert = s "SELECT id, to_char(updated_at, 'YYYY-MM-DD HH24:MI:SS') as updated_at FROM builds"
-
-      expect(after_insert['updated_at']).to eql("2000-01-01 12:00:00")
-
-      e "UPDATE builds SET number = '11', updated_at = TIMESTAMP '2001-01-01 12:00:00';"
-      after_update = s "SELECT id, to_char(updated_at, 'YYYY-MM-DD HH24:MI:SS') as updated_at FROM builds"
-
-      expect(after_update['updated_at']).to eql("2001-01-01 12:00:00")
     end
 
     it 'works also for new columns' do

--- a/spec/travis_migrations_spec.rb
+++ b/spec/travis_migrations_spec.rb
@@ -14,6 +14,14 @@ describe 'Rake tasks' do
     )
   }
 
+  before do
+    ActiveRecord::Base.establish_connection(config['test'])
+  end
+
+  after do
+    ActiveRecord::Base.remove_connection
+  end
+
   def run(cmd)
     system "RAILS_ENV=test bundle exec #{cmd}"
     expect($?.exitstatus).to eq 0
@@ -22,15 +30,13 @@ describe 'Rake tasks' do
   describe 'rake db:create' do
     it 'migrates the main db' do
       run 'rake db:drop db:create db:migrate'
-      ActiveRecord::Base.establish_connection(config['test'])
       expect(tables.sort).to eq expected_main_tables.sort
     end
   end
 
   describe 'rake db:schema:load' do
     it 'loads the main schema'do
-    run 'rake db:drop db:create db:structure:load'
-    ActiveRecord::Base.establish_connection(config['test'])
+      run 'rake db:drop db:create db:structure:load'
       expect(tables.sort).to eq expected_main_tables.sort
     end
   end

--- a/spec/travis_migrations_spec.rb
+++ b/spec/travis_migrations_spec.rb
@@ -34,7 +34,7 @@ describe 'Rake tasks' do
     end
   end
 
-  describe 'rake db:schema:load' do
+  describe 'rake db:structure:load' do
     it 'loads the main schema'do
       run 'rake db:drop db:create db:structure:load'
       expect(tables.sort).to eq expected_main_tables.sort


### PR DESCRIPTION
This PR adds triggers on builds and jobs tables that set `updated_at`
field to `now()` on `INSERT` and on `UPDATE`, with an exception of not
setting the column when a row hasn't been changed.