### PR TITLE
new conditional index: index_builds_on_repository_id_and_branch_and_event_type

### DIFF
--- a/db/main/migrate/20171211000000_add_repository_id_branch_event_type_index_on_builds.rb
+++ b/db/main/migrate/20171211000000_add_repository_id_branch_event_type_index_on_builds.rb
@@ -1,0 +1,11 @@
+class AddRepositoryIdBranchEventTypeIndexOnBuilds < ActiveRecord::Migration
+  self.disable_ddl_transaction!
+
+  def up
+    execute "CREATE INDEX CONCURRENTLY index_builds_on_repository_id_and_branch_and_event_type ON builds (repository_id, branch, event_type) WHERE state IN ('created', 'queued', 'received')"
+  end
+
+  def down
+    execute "DROP INDEX CONCURRENTLY index_builds_on_repository_id_and_branch_and_event_type"
+  end
+end


### PR DESCRIPTION
Drops the average for our current most expensive query from 800ms to 0ms. 👍 

![screen shot 2017-12-11 at 15 29 02](https://user-images.githubusercontent.com/11158255/33835843-0d3d46f6-de88-11e7-9a6e-df6d15e845ba.png)
