### PR TITLE
Add index on repositories(owner_id, owner_type)

### DIFF
--- a/db/main/migrate/20180130000000_add_repositories_owner_id_owner_type_index.rb
+++ b/db/main/migrate/20180130000000_add_repositories_owner_id_owner_type_index.rb
@@ -1,0 +1,11 @@
+class AddRepositoriesOwnerIdOwnerTypeIndex < ActiveRecord::Migration
+  self.disable_ddl_transaction!
+
+  def up
+    execute "CREATE INDEX CONCURRENTLY index_repositories_on_owner_id_owner_type ON repositories (owner_id, owner_type)"
+  end
+
+  def down
+    execute "DROP INDEX CONCURRENTLY index_repositories_on_owner_id_owner_type"
+  end
+end


### PR DESCRIPTION
This is needed for queries where we need to get only repositories where
we want only a specific owner_type.

I need it specifically for https://github.com/travis-ci/travis-api/pull/631