### PR TITLE
delete DATABASE_URL from ENV in spec_helper

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+ENV.delete('DATABASE_URL')
+
 require 'active_record'
 
 RSpec.configure do |config|


### PR DESCRIPTION
extra safety net for not accidentally running specs against a remote database