### PR TITLE
Unique installations by github id, index repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Any changes to this document should also be reflected in the [Travis Builders Ma
 
 In short, migrations should be run locally while standing in this repository during development. For tests (e.g. via `.travis.yml`) applications should contain their own tooling that loads the schema (e.g. see [travis-hub](https://github.com/travis-ci/travis-hub/blob/master/Rakefile#L12)).
 
-Please use Postgresql 9.4 for local development and testing, but note that production and enterprise environments require compatibility with both 9.3 and 9.6.
+Please use Postgresql 9.6.8 for local development and testing, but note that production and enterprise environments require compatibility with both 9.3 and 9.6.
 
 Installing
 ----------

--- a/db/main/migrate/20180420000000_constraints_and_indexes_for_gh_apps.rb
+++ b/db/main/migrate/20180420000000_constraints_and_indexes_for_gh_apps.rb
@@ -1,0 +1,13 @@
+class ConstraintsAndIndexesForGhApps < ActiveRecord::Migration[4.2]
+  self.disable_ddl_transaction!
+
+  def up
+    execute "ALTER TABLE installations ADD CONSTRAINT unique_github_id_on_installations UNIQUE (github_id)"
+    execute "CREATE INDEX CONCURRENTLY index_repositories_on_managed ON repositories (managed_by_installation_at)"
+  end
+
+  def down
+    execute "ALTER TABLE installations DROP CONSTRAINT unique_github_id_on_installations"
+    execute "DROP INDEX CONCURRENTLY index_repositories_on_managed"
+  end
+end

--- a/db/main/migrate/20180420000000_constraints_and_indexes_for_gh_apps.rb
+++ b/db/main/migrate/20180420000000_constraints_and_indexes_for_gh_apps.rb
@@ -4,10 +4,14 @@ class ConstraintsAndIndexesForGhApps < ActiveRecord::Migration[4.2]
   def up
     execute "ALTER TABLE installations ADD CONSTRAINT unique_github_id_on_installations UNIQUE (github_id)"
     execute "CREATE INDEX CONCURRENTLY index_repositories_on_managed ON repositories (managed_by_installation_at)"
+    execute "CREATE UNIQUE INDEX CONCURRENTLY favo_3col_uni_idx ON installations (owner_id, owner_type, removed_by_id) WHERE removed_by_id IS NOT NULL"
+    execute "CREATE UNIQUE INDEX favo_2col_uni_idx ON installations (owner_id, owner_type) WHERE removed_by_id IS NULL"
   end
 
   def down
     execute "ALTER TABLE installations DROP CONSTRAINT unique_github_id_on_installations"
     execute "DROP INDEX CONCURRENTLY index_repositories_on_managed"
+    execute "DROP INDEX CONCURRENTLY favo_3col_uni_idx"
+    execute "DROP INDEX CONCURRENTLY favo_2col_uni_idx"
   end
 end

--- a/db/main/migrate/20180420000000_constraints_and_indexes_for_gh_apps.rb
+++ b/db/main/migrate/20180420000000_constraints_and_indexes_for_gh_apps.rb
@@ -4,14 +4,14 @@ class ConstraintsAndIndexesForGhApps < ActiveRecord::Migration[4.2]
   def up
     execute "CREATE UNIQUE INDEX CONCURRENTLY github_id_installations_idx ON installations (github_id)"
     execute "CREATE INDEX CONCURRENTLY managed_repositories_idx ON repositories (managed_by_installation_at)"
-    execute "CREATE UNIQUE INDEX CONCURRENTLY favo_3col_uni_idx ON installations (owner_id, owner_type, removed_by_id) WHERE removed_by_id IS NOT NULL"
-    execute "CREATE UNIQUE INDEX favo_2col_uni_idx ON installations (owner_id, owner_type) WHERE removed_by_id IS NULL"
+    execute "CREATE UNIQUE INDEX CONCURRENTLY owner_removed_installations_idx ON installations (owner_id, owner_type, removed_by_id) WHERE removed_by_id IS NOT NULL"
+    execute "CREATE UNIQUE INDEX CONCURRENTLY owner_installations_idx ON installations (owner_id, owner_type) WHERE removed_by_id IS NULL"
   end
 
   def down
     execute "DROP INDEX CONCURRENTLY github_id_installations_idx"
     execute "DROP INDEX CONCURRENTLY managed_repositories_idx"
-    execute "DROP INDEX CONCURRENTLY favo_3col_uni_idx"
-    execute "DROP INDEX CONCURRENTLY favo_2col_uni_idx"
+    execute "DROP INDEX CONCURRENTLY owner_removed_installations_idx"
+    execute "DROP INDEX CONCURRENTLY owner_installations_idx"
   end
 end

--- a/db/main/migrate/20180420000000_constraints_and_indexes_for_gh_apps.rb
+++ b/db/main/migrate/20180420000000_constraints_and_indexes_for_gh_apps.rb
@@ -2,15 +2,15 @@ class ConstraintsAndIndexesForGhApps < ActiveRecord::Migration[4.2]
   self.disable_ddl_transaction!
 
   def up
-    execute "ALTER TABLE installations ADD CONSTRAINT unique_github_id_on_installations UNIQUE (github_id)"
-    execute "CREATE INDEX CONCURRENTLY index_repositories_on_managed ON repositories (managed_by_installation_at)"
+    execute "CREATE UNIQUE INDEX CONCURRENTLY github_id_installations_idx ON installations (github_id)"
+    execute "CREATE INDEX CONCURRENTLY managed_repositories_idx ON repositories (managed_by_installation_at)"
     execute "CREATE UNIQUE INDEX CONCURRENTLY favo_3col_uni_idx ON installations (owner_id, owner_type, removed_by_id) WHERE removed_by_id IS NOT NULL"
     execute "CREATE UNIQUE INDEX favo_2col_uni_idx ON installations (owner_id, owner_type) WHERE removed_by_id IS NULL"
   end
 
   def down
-    execute "ALTER TABLE installations DROP CONSTRAINT unique_github_id_on_installations"
-    execute "DROP INDEX CONCURRENTLY index_repositories_on_managed"
+    execute "DROP INDEX CONCURRENTLY github_id_installations_idx"
+    execute "DROP INDEX CONCURRENTLY managed_repositories_idx"
     execute "DROP INDEX CONCURRENTLY favo_3col_uni_idx"
     execute "DROP INDEX CONCURRENTLY favo_2col_uni_idx"
   end

--- a/db/main/structure.sql
+++ b/db/main/structure.sql
@@ -3,6 +3,7 @@ SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
 SET client_min_messages = warning;
 SET row_security = off;
@@ -49,13 +50,11 @@ CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public;
 COMMENT ON EXTENSION pgcrypto IS 'cryptographic functions';
 
 
-SET search_path = public, pg_catalog;
-
 --
 -- Name: source_type; Type: TYPE; Schema: public; Owner: -
 --
 
-CREATE TYPE source_type AS ENUM (
+CREATE TYPE public.source_type AS ENUM (
     'manual',
     'stripe',
     'github',
@@ -67,7 +66,7 @@ CREATE TYPE source_type AS ENUM (
 -- Name: agg_all_repo_counts(); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION agg_all_repo_counts() RETURNS boolean
+CREATE FUNCTION public.agg_all_repo_counts() RETURNS boolean
     LANGUAGE plpgsql
     AS $$
 begin
@@ -129,7 +128,7 @@ $$;
 -- Name: agg_repo_counts(integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION agg_repo_counts(_repo_id integer) RETURNS boolean
+CREATE FUNCTION public.agg_repo_counts(_repo_id integer) RETURNS boolean
     LANGUAGE plpgsql
     AS $$
 begin
@@ -193,7 +192,7 @@ $$;
 -- Name: count_all_branches(integer, integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION count_all_branches(_count integer, _start integer, _end integer) RETURNS boolean
+CREATE FUNCTION public.count_all_branches(_count integer, _start integer, _end integer) RETURNS boolean
     LANGUAGE plpgsql
     AS $$
 declare max int;
@@ -218,7 +217,7 @@ $$;
 -- Name: count_all_builds(integer, integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION count_all_builds(_count integer, _start integer, _end integer) RETURNS boolean
+CREATE FUNCTION public.count_all_builds(_count integer, _start integer, _end integer) RETURNS boolean
     LANGUAGE plpgsql
     AS $$
 declare max int;
@@ -243,7 +242,7 @@ $$;
 -- Name: count_all_commits(integer, integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION count_all_commits(_count integer, _start integer, _end integer) RETURNS boolean
+CREATE FUNCTION public.count_all_commits(_count integer, _start integer, _end integer) RETURNS boolean
     LANGUAGE plpgsql
     AS $$
 declare max int;
@@ -268,7 +267,7 @@ $$;
 -- Name: count_all_jobs(integer, integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION count_all_jobs(_count integer, _start integer, _end integer) RETURNS boolean
+CREATE FUNCTION public.count_all_jobs(_count integer, _start integer, _end integer) RETURNS boolean
     LANGUAGE plpgsql
     AS $$
 declare max int;
@@ -293,7 +292,7 @@ $$;
 -- Name: count_all_pull_requests(integer, integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION count_all_pull_requests(_count integer, _start integer, _end integer) RETURNS boolean
+CREATE FUNCTION public.count_all_pull_requests(_count integer, _start integer, _end integer) RETURNS boolean
     LANGUAGE plpgsql
     AS $$
 declare max int;
@@ -318,7 +317,7 @@ $$;
 -- Name: count_all_requests(integer, integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION count_all_requests(_count integer, _start integer, _end integer) RETURNS boolean
+CREATE FUNCTION public.count_all_requests(_count integer, _start integer, _end integer) RETURNS boolean
     LANGUAGE plpgsql
     AS $$
 declare max int;
@@ -342,7 +341,7 @@ $$;
 -- Name: count_all_tags(integer, integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION count_all_tags(_count integer, _start integer, _end integer) RETURNS boolean
+CREATE FUNCTION public.count_all_tags(_count integer, _start integer, _end integer) RETURNS boolean
     LANGUAGE plpgsql
     AS $$
 declare max int;
@@ -367,7 +366,7 @@ $$;
 -- Name: count_branches(); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION count_branches() RETURNS trigger
+CREATE FUNCTION public.count_branches() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 declare
@@ -392,7 +391,7 @@ $$;
 -- Name: count_branches(integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION count_branches(_start integer, _end integer) RETURNS TABLE(repository_id integer, branches bigint, range character varying)
+CREATE FUNCTION public.count_branches(_start integer, _end integer) RETURNS TABLE(repository_id integer, branches bigint, range character varying)
     LANGUAGE plpgsql
     AS $$
 begin
@@ -409,7 +408,7 @@ $$;
 -- Name: count_builds(); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION count_builds() RETURNS trigger
+CREATE FUNCTION public.count_builds() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 declare
@@ -434,7 +433,7 @@ $$;
 -- Name: count_builds(integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION count_builds(_start integer, _end integer) RETURNS TABLE(repository_id integer, builds bigint, range character varying)
+CREATE FUNCTION public.count_builds(_start integer, _end integer) RETURNS TABLE(repository_id integer, builds bigint, range character varying)
     LANGUAGE plpgsql
     AS $$
 begin
@@ -450,7 +449,7 @@ $$;
 -- Name: count_commits(); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION count_commits() RETURNS trigger
+CREATE FUNCTION public.count_commits() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 declare
@@ -475,7 +474,7 @@ $$;
 -- Name: count_commits(integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION count_commits(_start integer, _end integer) RETURNS TABLE(repository_id integer, commits bigint, range character varying)
+CREATE FUNCTION public.count_commits(_start integer, _end integer) RETURNS TABLE(repository_id integer, commits bigint, range character varying)
     LANGUAGE plpgsql
     AS $$
 begin
@@ -492,7 +491,7 @@ $$;
 -- Name: count_jobs(); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION count_jobs() RETURNS trigger
+CREATE FUNCTION public.count_jobs() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 declare
@@ -517,7 +516,7 @@ $$;
 -- Name: count_jobs(integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION count_jobs(_start integer, _end integer) RETURNS TABLE(repository_id integer, jobs bigint, range character varying)
+CREATE FUNCTION public.count_jobs(_start integer, _end integer) RETURNS TABLE(repository_id integer, jobs bigint, range character varying)
     LANGUAGE plpgsql
     AS $$
 begin
@@ -533,7 +532,7 @@ $$;
 -- Name: count_pull_requests(); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION count_pull_requests() RETURNS trigger
+CREATE FUNCTION public.count_pull_requests() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 declare
@@ -558,7 +557,7 @@ $$;
 -- Name: count_pull_requests(integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION count_pull_requests(_start integer, _end integer) RETURNS TABLE(repository_id integer, pull_requests bigint, range character varying)
+CREATE FUNCTION public.count_pull_requests(_start integer, _end integer) RETURNS TABLE(repository_id integer, pull_requests bigint, range character varying)
     LANGUAGE plpgsql
     AS $$
 begin
@@ -575,7 +574,7 @@ $$;
 -- Name: count_requests(); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION count_requests() RETURNS trigger
+CREATE FUNCTION public.count_requests() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 declare
@@ -600,7 +599,7 @@ $$;
 -- Name: count_requests(integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION count_requests(_start integer, _end integer) RETURNS TABLE(repository_id integer, requests bigint, range character varying)
+CREATE FUNCTION public.count_requests(_start integer, _end integer) RETURNS TABLE(repository_id integer, requests bigint, range character varying)
     LANGUAGE plpgsql
     AS $$
 begin
@@ -616,7 +615,7 @@ $$;
 -- Name: count_tags(); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION count_tags() RETURNS trigger
+CREATE FUNCTION public.count_tags() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 declare
@@ -641,7 +640,7 @@ $$;
 -- Name: count_tags(integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION count_tags(_start integer, _end integer) RETURNS TABLE(repository_id integer, tags bigint, range character varying)
+CREATE FUNCTION public.count_tags(_start integer, _end integer) RETURNS TABLE(repository_id integer, tags bigint, range character varying)
     LANGUAGE plpgsql
     AS $$
 begin
@@ -658,7 +657,7 @@ $$;
 -- Name: set_updated_at(); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION set_updated_at() RETURNS trigger
+CREATE FUNCTION public.set_updated_at() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
       BEGIN
@@ -679,10 +678,10 @@ SET default_with_oids = false;
 -- Name: abuses; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE abuses (
+CREATE TABLE public.abuses (
     id integer NOT NULL,
-    owner_type character varying,
     owner_id integer,
+    owner_type character varying,
     request_id integer,
     level integer NOT NULL,
     reason character varying NOT NULL,
@@ -695,7 +694,7 @@ CREATE TABLE abuses (
 -- Name: abuses_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE abuses_id_seq
+CREATE SEQUENCE public.abuses_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -707,14 +706,14 @@ CREATE SEQUENCE abuses_id_seq
 -- Name: abuses_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE abuses_id_seq OWNED BY abuses.id;
+ALTER SEQUENCE public.abuses_id_seq OWNED BY public.abuses.id;
 
 
 --
 -- Name: ar_internal_metadata; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE ar_internal_metadata (
+CREATE TABLE public.ar_internal_metadata (
     key character varying NOT NULL,
     value character varying,
     created_at timestamp without time zone NOT NULL,
@@ -726,7 +725,7 @@ CREATE TABLE ar_internal_metadata (
 -- Name: beta_features; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE beta_features (
+CREATE TABLE public.beta_features (
     id integer NOT NULL,
     name character varying,
     description text,
@@ -742,7 +741,7 @@ CREATE TABLE beta_features (
 -- Name: beta_features_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE beta_features_id_seq
+CREATE SEQUENCE public.beta_features_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -754,14 +753,14 @@ CREATE SEQUENCE beta_features_id_seq
 -- Name: beta_features_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE beta_features_id_seq OWNED BY beta_features.id;
+ALTER SEQUENCE public.beta_features_id_seq OWNED BY public.beta_features.id;
 
 
 --
 -- Name: branches; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE branches (
+CREATE TABLE public.branches (
     id integer NOT NULL,
     repository_id integer NOT NULL,
     last_build_id integer,
@@ -778,7 +777,7 @@ CREATE TABLE branches (
 -- Name: branches_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE branches_id_seq
+CREATE SEQUENCE public.branches_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -790,17 +789,17 @@ CREATE SEQUENCE branches_id_seq
 -- Name: branches_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE branches_id_seq OWNED BY branches.id;
+ALTER SEQUENCE public.branches_id_seq OWNED BY public.branches.id;
 
 
 --
 -- Name: broadcasts; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE broadcasts (
+CREATE TABLE public.broadcasts (
     id integer NOT NULL,
-    recipient_type character varying,
     recipient_id integer,
+    recipient_type character varying,
     kind character varying,
     message character varying,
     expired boolean,
@@ -814,7 +813,7 @@ CREATE TABLE broadcasts (
 -- Name: broadcasts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE broadcasts_id_seq
+CREATE SEQUENCE public.broadcasts_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -826,18 +825,18 @@ CREATE SEQUENCE broadcasts_id_seq
 -- Name: broadcasts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE broadcasts_id_seq OWNED BY broadcasts.id;
+ALTER SEQUENCE public.broadcasts_id_seq OWNED BY public.broadcasts.id;
 
 
 --
 -- Name: build_configs; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE build_configs (
+CREATE TABLE public.build_configs (
     id integer NOT NULL,
     repository_id integer NOT NULL,
     key character varying NOT NULL,
-    config jsonb
+    config text
 );
 
 
@@ -845,7 +844,7 @@ CREATE TABLE build_configs (
 -- Name: build_configs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE build_configs_id_seq
+CREATE SEQUENCE public.build_configs_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -857,14 +856,14 @@ CREATE SEQUENCE build_configs_id_seq
 -- Name: build_configs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE build_configs_id_seq OWNED BY build_configs.id;
+ALTER SEQUENCE public.build_configs_id_seq OWNED BY public.build_configs.id;
 
 
 --
 -- Name: shared_builds_tasks_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE shared_builds_tasks_seq
+CREATE SEQUENCE public.shared_builds_tasks_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -876,37 +875,26 @@ CREATE SEQUENCE shared_builds_tasks_seq
 -- Name: builds; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE builds (
-    id bigint DEFAULT nextval('shared_builds_tasks_seq'::regclass) NOT NULL,
+CREATE TABLE public.builds (
+    id bigint DEFAULT nextval('public.shared_builds_tasks_seq'::regclass) NOT NULL,
     repository_id integer,
     number character varying,
     started_at timestamp without time zone,
     finished_at timestamp without time zone,
-    log text DEFAULT ''::text,
-    message text,
-    committed_at timestamp without time zone,
-    committer_name character varying,
-    committer_email character varying,
-    author_name character varying,
-    author_email character varying,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     config text,
-    ref character varying,
-    branch character varying,
-    github_payload text,
-    compare_url character varying,
-    token character varying,
     commit_id integer,
     request_id integer,
     state character varying,
     duration integer,
-    owner_type character varying,
     owner_id integer,
+    owner_type character varying,
     event_type character varying,
     previous_state character varying,
     pull_request_title text,
     pull_request_number integer,
+    branch character varying,
     canceled_at timestamp without time zone,
     cached_matrix_ids integer[],
     received_at timestamp without time zone,
@@ -914,8 +902,8 @@ CREATE TABLE builds (
     pull_request_id integer,
     branch_id integer,
     tag_id integer,
-    sender_type character varying,
     sender_id integer,
+    sender_type character varying,
     org_id integer,
     com_id integer,
     config_id integer
@@ -926,7 +914,7 @@ CREATE TABLE builds (
 -- Name: builds_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE builds_id_seq
+CREATE SEQUENCE public.builds_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -938,14 +926,14 @@ CREATE SEQUENCE builds_id_seq
 -- Name: builds_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE builds_id_seq OWNED BY builds.id;
+ALTER SEQUENCE public.builds_id_seq OWNED BY public.builds.id;
 
 
 --
 -- Name: commits; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE commits (
+CREATE TABLE public.commits (
     id integer NOT NULL,
     repository_id integer,
     commit character varying,
@@ -971,7 +959,7 @@ CREATE TABLE commits (
 -- Name: commits_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE commits_id_seq
+CREATE SEQUENCE public.commits_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -983,14 +971,14 @@ CREATE SEQUENCE commits_id_seq
 -- Name: commits_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE commits_id_seq OWNED BY commits.id;
+ALTER SEQUENCE public.commits_id_seq OWNED BY public.commits.id;
 
 
 --
 -- Name: coupons; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE coupons (
+CREATE TABLE public.coupons (
     id integer NOT NULL,
     percent_off integer,
     coupon_id character varying,
@@ -1007,7 +995,7 @@ CREATE TABLE coupons (
 -- Name: coupons_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE coupons_id_seq
+CREATE SEQUENCE public.coupons_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1019,14 +1007,14 @@ CREATE SEQUENCE coupons_id_seq
 -- Name: coupons_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE coupons_id_seq OWNED BY coupons.id;
+ALTER SEQUENCE public.coupons_id_seq OWNED BY public.coupons.id;
 
 
 --
 -- Name: crons; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE crons (
+CREATE TABLE public.crons (
     id integer NOT NULL,
     branch_id integer,
     "interval" character varying NOT NULL,
@@ -1044,7 +1032,7 @@ CREATE TABLE crons (
 -- Name: crons_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE crons_id_seq
+CREATE SEQUENCE public.crons_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1056,14 +1044,14 @@ CREATE SEQUENCE crons_id_seq
 -- Name: crons_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE crons_id_seq OWNED BY crons.id;
+ALTER SEQUENCE public.crons_id_seq OWNED BY public.crons.id;
 
 
 --
 -- Name: emails; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE emails (
+CREATE TABLE public.emails (
     id integer NOT NULL,
     user_id integer,
     email character varying,
@@ -1076,7 +1064,7 @@ CREATE TABLE emails (
 -- Name: emails_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE emails_id_seq
+CREATE SEQUENCE public.emails_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1088,19 +1076,19 @@ CREATE SEQUENCE emails_id_seq
 -- Name: emails_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE emails_id_seq OWNED BY emails.id;
+ALTER SEQUENCE public.emails_id_seq OWNED BY public.emails.id;
 
 
 --
 -- Name: installations; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE installations (
+CREATE TABLE public.installations (
     id integer NOT NULL,
     github_id integer,
     permissions jsonb,
-    owner_type character varying,
     owner_id integer,
+    owner_type character varying,
     added_by_id integer,
     removed_by_id integer,
     created_at timestamp without time zone,
@@ -1112,7 +1100,7 @@ CREATE TABLE installations (
 -- Name: installations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE installations_id_seq
+CREATE SEQUENCE public.installations_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1124,14 +1112,14 @@ CREATE SEQUENCE installations_id_seq
 -- Name: installations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE installations_id_seq OWNED BY installations.id;
+ALTER SEQUENCE public.installations_id_seq OWNED BY public.installations.id;
 
 
 --
 -- Name: invoices; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE invoices (
+CREATE TABLE public.invoices (
     id integer NOT NULL,
     object text,
     created_at timestamp without time zone,
@@ -1147,7 +1135,7 @@ CREATE TABLE invoices (
 -- Name: invoices_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE invoices_id_seq
+CREATE SEQUENCE public.invoices_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1159,18 +1147,18 @@ CREATE SEQUENCE invoices_id_seq
 -- Name: invoices_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE invoices_id_seq OWNED BY invoices.id;
+ALTER SEQUENCE public.invoices_id_seq OWNED BY public.invoices.id;
 
 
 --
 -- Name: job_configs; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE job_configs (
+CREATE TABLE public.job_configs (
     id integer NOT NULL,
     repository_id integer NOT NULL,
     key character varying NOT NULL,
-    config jsonb
+    config text
 );
 
 
@@ -1178,7 +1166,7 @@ CREATE TABLE job_configs (
 -- Name: job_configs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE job_configs_id_seq
+CREATE SEQUENCE public.job_configs_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1190,25 +1178,24 @@ CREATE SEQUENCE job_configs_id_seq
 -- Name: job_configs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE job_configs_id_seq OWNED BY job_configs.id;
+ALTER SEQUENCE public.job_configs_id_seq OWNED BY public.job_configs.id;
 
 
 --
 -- Name: jobs; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE jobs (
-    id bigint DEFAULT nextval('shared_builds_tasks_seq'::regclass) NOT NULL,
+CREATE TABLE public.jobs (
+    id bigint DEFAULT nextval('public.shared_builds_tasks_seq'::regclass) NOT NULL,
     repository_id integer,
     commit_id integer,
-    source_type character varying,
     source_id integer,
+    source_type character varying,
     queue character varying,
     type character varying,
     state character varying,
     number character varying,
     config text,
-    log text DEFAULT ''::text,
     worker character varying,
     started_at timestamp without time zone,
     finished_at timestamp without time zone,
@@ -1216,8 +1203,8 @@ CREATE TABLE jobs (
     updated_at timestamp without time zone NOT NULL,
     tags text,
     allow_failure boolean DEFAULT false,
-    owner_type character varying,
     owner_id integer,
+    owner_type character varying,
     result integer,
     queued_at timestamp without time zone,
     canceled_at timestamp without time zone,
@@ -1236,7 +1223,7 @@ CREATE TABLE jobs (
 -- Name: jobs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE jobs_id_seq
+CREATE SEQUENCE public.jobs_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1248,14 +1235,14 @@ CREATE SEQUENCE jobs_id_seq
 -- Name: jobs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE jobs_id_seq OWNED BY jobs.id;
+ALTER SEQUENCE public.jobs_id_seq OWNED BY public.jobs.id;
 
 
 --
 -- Name: memberships; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE memberships (
+CREATE TABLE public.memberships (
     id integer NOT NULL,
     organization_id integer,
     user_id integer,
@@ -1267,7 +1254,7 @@ CREATE TABLE memberships (
 -- Name: memberships_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE memberships_id_seq
+CREATE SEQUENCE public.memberships_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1279,14 +1266,14 @@ CREATE SEQUENCE memberships_id_seq
 -- Name: memberships_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE memberships_id_seq OWNED BY memberships.id;
+ALTER SEQUENCE public.memberships_id_seq OWNED BY public.memberships.id;
 
 
 --
 -- Name: messages; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE messages (
+CREATE TABLE public.messages (
     id integer NOT NULL,
     subject_id integer,
     subject_type character varying,
@@ -1303,7 +1290,7 @@ CREATE TABLE messages (
 -- Name: messages_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE messages_id_seq
+CREATE SEQUENCE public.messages_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1315,14 +1302,14 @@ CREATE SEQUENCE messages_id_seq
 -- Name: messages_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE messages_id_seq OWNED BY messages.id;
+ALTER SEQUENCE public.messages_id_seq OWNED BY public.messages.id;
 
 
 --
 -- Name: organizations; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE organizations (
+CREATE TABLE public.organizations (
     id integer NOT NULL,
     name character varying,
     login character varying,
@@ -1346,7 +1333,7 @@ CREATE TABLE organizations (
 -- Name: organizations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE organizations_id_seq
+CREATE SEQUENCE public.organizations_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1358,18 +1345,18 @@ CREATE SEQUENCE organizations_id_seq
 -- Name: organizations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE organizations_id_seq OWNED BY organizations.id;
+ALTER SEQUENCE public.organizations_id_seq OWNED BY public.organizations.id;
 
 
 --
 -- Name: owner_groups; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE owner_groups (
+CREATE TABLE public.owner_groups (
     id integer NOT NULL,
     uuid character varying,
-    owner_type character varying,
     owner_id integer,
+    owner_type character varying,
     created_at timestamp without time zone,
     updated_at timestamp without time zone
 );
@@ -1379,7 +1366,7 @@ CREATE TABLE owner_groups (
 -- Name: owner_groups_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE owner_groups_id_seq
+CREATE SEQUENCE public.owner_groups_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1391,14 +1378,14 @@ CREATE SEQUENCE owner_groups_id_seq
 -- Name: owner_groups_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE owner_groups_id_seq OWNED BY owner_groups.id;
+ALTER SEQUENCE public.owner_groups_id_seq OWNED BY public.owner_groups.id;
 
 
 --
 -- Name: permissions; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE permissions (
+CREATE TABLE public.permissions (
     id integer NOT NULL,
     user_id integer,
     repository_id integer,
@@ -1414,7 +1401,7 @@ CREATE TABLE permissions (
 -- Name: permissions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE permissions_id_seq
+CREATE SEQUENCE public.permissions_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1426,14 +1413,14 @@ CREATE SEQUENCE permissions_id_seq
 -- Name: permissions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE permissions_id_seq OWNED BY permissions.id;
+ALTER SEQUENCE public.permissions_id_seq OWNED BY public.permissions.id;
 
 
 --
 -- Name: pull_requests; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE pull_requests (
+CREATE TABLE public.pull_requests (
     id integer NOT NULL,
     repository_id integer,
     number integer,
@@ -1453,7 +1440,7 @@ CREATE TABLE pull_requests (
 -- Name: pull_requests_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE pull_requests_id_seq
+CREATE SEQUENCE public.pull_requests_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1465,14 +1452,14 @@ CREATE SEQUENCE pull_requests_id_seq
 -- Name: pull_requests_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE pull_requests_id_seq OWNED BY pull_requests.id;
+ALTER SEQUENCE public.pull_requests_id_seq OWNED BY public.pull_requests.id;
 
 
 --
 -- Name: queueable_jobs; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE queueable_jobs (
+CREATE TABLE public.queueable_jobs (
     id integer NOT NULL,
     job_id integer
 );
@@ -1482,7 +1469,7 @@ CREATE TABLE queueable_jobs (
 -- Name: queueable_jobs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE queueable_jobs_id_seq
+CREATE SEQUENCE public.queueable_jobs_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1494,14 +1481,14 @@ CREATE SEQUENCE queueable_jobs_id_seq
 -- Name: queueable_jobs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE queueable_jobs_id_seq OWNED BY queueable_jobs.id;
+ALTER SEQUENCE public.queueable_jobs_id_seq OWNED BY public.queueable_jobs.id;
 
 
 --
 -- Name: repo_counts; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE repo_counts (
+CREATE TABLE public.repo_counts (
     repository_id integer NOT NULL,
     requests integer,
     commits integer,
@@ -1519,7 +1506,7 @@ CREATE TABLE repo_counts (
 -- Name: repositories; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE repositories (
+CREATE TABLE public.repositories (
     id integer NOT NULL,
     name character varying,
     url character varying,
@@ -1534,8 +1521,8 @@ CREATE TABLE repositories (
     active boolean,
     description text,
     last_build_duration integer,
-    owner_type character varying,
     owner_id integer,
+    owner_type character varying,
     private boolean DEFAULT false,
     last_build_state character varying,
     github_id integer,
@@ -1558,7 +1545,7 @@ CREATE TABLE repositories (
 -- Name: repositories_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE repositories_id_seq
+CREATE SEQUENCE public.repositories_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1570,18 +1557,18 @@ CREATE SEQUENCE repositories_id_seq
 -- Name: repositories_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE repositories_id_seq OWNED BY repositories.id;
+ALTER SEQUENCE public.repositories_id_seq OWNED BY public.repositories.id;
 
 
 --
 -- Name: request_configs; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE request_configs (
+CREATE TABLE public.request_configs (
     id integer NOT NULL,
     repository_id integer NOT NULL,
     key character varying NOT NULL,
-    config jsonb
+    config text
 );
 
 
@@ -1589,7 +1576,7 @@ CREATE TABLE request_configs (
 -- Name: request_configs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE request_configs_id_seq
+CREATE SEQUENCE public.request_configs_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1601,14 +1588,14 @@ CREATE SEQUENCE request_configs_id_seq
 -- Name: request_configs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE request_configs_id_seq OWNED BY request_configs.id;
+ALTER SEQUENCE public.request_configs_id_seq OWNED BY public.request_configs.id;
 
 
 --
 -- Name: request_payloads; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE request_payloads (
+CREATE TABLE public.request_payloads (
     id integer NOT NULL,
     request_id integer NOT NULL,
     payload text,
@@ -1621,7 +1608,7 @@ CREATE TABLE request_payloads (
 -- Name: request_payloads_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE request_payloads_id_seq
+CREATE SEQUENCE public.request_payloads_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1633,14 +1620,14 @@ CREATE SEQUENCE request_payloads_id_seq
 -- Name: request_payloads_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE request_payloads_id_seq OWNED BY request_payloads.id;
+ALTER SEQUENCE public.request_payloads_id_seq OWNED BY public.request_payloads.id;
 
 
 --
 -- Name: requests; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE requests (
+CREATE TABLE public.requests (
     id integer NOT NULL,
     repository_id integer,
     commit_id integer,
@@ -1656,16 +1643,16 @@ CREATE TABLE requests (
     comments_url character varying,
     base_commit character varying,
     head_commit character varying,
-    owner_type character varying,
     owner_id integer,
+    owner_type character varying,
     result character varying,
     message character varying,
     private boolean,
     pull_request_id integer,
     branch_id integer,
     tag_id integer,
-    sender_type character varying,
     sender_id integer,
+    sender_type character varying,
     org_id integer,
     com_id integer,
     config_id integer
@@ -1676,7 +1663,7 @@ CREATE TABLE requests (
 -- Name: requests_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE requests_id_seq
+CREATE SEQUENCE public.requests_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1688,14 +1675,14 @@ CREATE SEQUENCE requests_id_seq
 -- Name: requests_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE requests_id_seq OWNED BY requests.id;
+ALTER SEQUENCE public.requests_id_seq OWNED BY public.requests.id;
 
 
 --
 -- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE schema_migrations (
+CREATE TABLE public.schema_migrations (
     version character varying NOT NULL
 );
 
@@ -1704,7 +1691,7 @@ CREATE TABLE schema_migrations (
 -- Name: ssl_keys; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE ssl_keys (
+CREATE TABLE public.ssl_keys (
     id integer NOT NULL,
     repository_id integer,
     public_key text,
@@ -1720,7 +1707,7 @@ CREATE TABLE ssl_keys (
 -- Name: ssl_keys_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE ssl_keys_id_seq
+CREATE SEQUENCE public.ssl_keys_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1732,14 +1719,14 @@ CREATE SEQUENCE ssl_keys_id_seq
 -- Name: ssl_keys_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE ssl_keys_id_seq OWNED BY ssl_keys.id;
+ALTER SEQUENCE public.ssl_keys_id_seq OWNED BY public.ssl_keys.id;
 
 
 --
 -- Name: stages; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE stages (
+CREATE TABLE public.stages (
     id integer NOT NULL,
     build_id integer,
     number integer,
@@ -1756,7 +1743,7 @@ CREATE TABLE stages (
 -- Name: stages_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE stages_id_seq
+CREATE SEQUENCE public.stages_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1768,14 +1755,14 @@ CREATE SEQUENCE stages_id_seq
 -- Name: stages_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE stages_id_seq OWNED BY stages.id;
+ALTER SEQUENCE public.stages_id_seq OWNED BY public.stages.id;
 
 
 --
 -- Name: stars; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE stars (
+CREATE TABLE public.stars (
     id integer NOT NULL,
     repository_id integer,
     user_id integer,
@@ -1788,7 +1775,7 @@ CREATE TABLE stars (
 -- Name: stars_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE stars_id_seq
+CREATE SEQUENCE public.stars_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1800,14 +1787,14 @@ CREATE SEQUENCE stars_id_seq
 -- Name: stars_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE stars_id_seq OWNED BY stars.id;
+ALTER SEQUENCE public.stars_id_seq OWNED BY public.stars.id;
 
 
 --
 -- Name: stripe_events; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE stripe_events (
+CREATE TABLE public.stripe_events (
     id integer NOT NULL,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
@@ -1822,7 +1809,7 @@ CREATE TABLE stripe_events (
 -- Name: stripe_events_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE stripe_events_id_seq
+CREATE SEQUENCE public.stripe_events_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1834,19 +1821,19 @@ CREATE SEQUENCE stripe_events_id_seq
 -- Name: stripe_events_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE stripe_events_id_seq OWNED BY stripe_events.id;
+ALTER SEQUENCE public.stripe_events_id_seq OWNED BY public.stripe_events.id;
 
 
 --
 -- Name: subscriptions; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE subscriptions (
+CREATE TABLE public.subscriptions (
     id integer NOT NULL,
     cc_token character varying,
     valid_to timestamp without time zone,
-    owner_type character varying,
     owner_id integer,
+    owner_type character varying,
     first_name character varying,
     last_name character varying,
     company character varying,
@@ -1870,7 +1857,7 @@ CREATE TABLE subscriptions (
     canceled_at timestamp without time zone,
     canceled_by_id integer,
     status character varying,
-    source source_type DEFAULT 'unknown'::source_type NOT NULL,
+    source public.source_type DEFAULT 'unknown'::public.source_type NOT NULL,
     concurrency integer
 );
 
@@ -1879,7 +1866,7 @@ CREATE TABLE subscriptions (
 -- Name: subscriptions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE subscriptions_id_seq
+CREATE SEQUENCE public.subscriptions_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1891,14 +1878,14 @@ CREATE SEQUENCE subscriptions_id_seq
 -- Name: subscriptions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE subscriptions_id_seq OWNED BY subscriptions.id;
+ALTER SEQUENCE public.subscriptions_id_seq OWNED BY public.subscriptions.id;
 
 
 --
 -- Name: tags; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE tags (
+CREATE TABLE public.tags (
     id integer NOT NULL,
     repository_id integer,
     name character varying,
@@ -1915,7 +1902,7 @@ CREATE TABLE tags (
 -- Name: tags_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE tags_id_seq
+CREATE SEQUENCE public.tags_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1927,14 +1914,14 @@ CREATE SEQUENCE tags_id_seq
 -- Name: tags_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE tags_id_seq OWNED BY tags.id;
+ALTER SEQUENCE public.tags_id_seq OWNED BY public.tags.id;
 
 
 --
 -- Name: tokens; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE tokens (
+CREATE TABLE public.tokens (
     id integer NOT NULL,
     user_id integer,
     token character varying,
@@ -1947,7 +1934,7 @@ CREATE TABLE tokens (
 -- Name: tokens_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE tokens_id_seq
+CREATE SEQUENCE public.tokens_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1959,14 +1946,14 @@ CREATE SEQUENCE tokens_id_seq
 -- Name: tokens_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE tokens_id_seq OWNED BY tokens.id;
+ALTER SEQUENCE public.tokens_id_seq OWNED BY public.tokens.id;
 
 
 --
 -- Name: trial_allowances; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE trial_allowances (
+CREATE TABLE public.trial_allowances (
     id integer NOT NULL,
     trial_id integer,
     creator_id integer,
@@ -1982,7 +1969,7 @@ CREATE TABLE trial_allowances (
 -- Name: trial_allowances_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE trial_allowances_id_seq
+CREATE SEQUENCE public.trial_allowances_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1994,17 +1981,17 @@ CREATE SEQUENCE trial_allowances_id_seq
 -- Name: trial_allowances_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE trial_allowances_id_seq OWNED BY trial_allowances.id;
+ALTER SEQUENCE public.trial_allowances_id_seq OWNED BY public.trial_allowances.id;
 
 
 --
 -- Name: trials; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE trials (
+CREATE TABLE public.trials (
     id integer NOT NULL,
-    owner_type character varying,
     owner_id integer,
+    owner_type character varying,
     chartmogul_customer_uuids text[] DEFAULT '{}'::text[],
     status character varying DEFAULT 'new'::character varying,
     created_at timestamp without time zone NOT NULL,
@@ -2016,7 +2003,7 @@ CREATE TABLE trials (
 -- Name: trials_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE trials_id_seq
+CREATE SEQUENCE public.trials_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2028,14 +2015,14 @@ CREATE SEQUENCE trials_id_seq
 -- Name: trials_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE trials_id_seq OWNED BY trials.id;
+ALTER SEQUENCE public.trials_id_seq OWNED BY public.trials.id;
 
 
 --
 -- Name: urls; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE urls (
+CREATE TABLE public.urls (
     id integer NOT NULL,
     url character varying,
     code character varying,
@@ -2048,7 +2035,7 @@ CREATE TABLE urls (
 -- Name: urls_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE urls_id_seq
+CREATE SEQUENCE public.urls_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2060,14 +2047,14 @@ CREATE SEQUENCE urls_id_seq
 -- Name: urls_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE urls_id_seq OWNED BY urls.id;
+ALTER SEQUENCE public.urls_id_seq OWNED BY public.urls.id;
 
 
 --
 -- Name: user_beta_features; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE user_beta_features (
+CREATE TABLE public.user_beta_features (
     id integer NOT NULL,
     user_id integer,
     beta_feature_id integer,
@@ -2081,7 +2068,7 @@ CREATE TABLE user_beta_features (
 -- Name: user_beta_features_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE user_beta_features_id_seq
+CREATE SEQUENCE public.user_beta_features_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2093,14 +2080,14 @@ CREATE SEQUENCE user_beta_features_id_seq
 -- Name: user_beta_features_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE user_beta_features_id_seq OWNED BY user_beta_features.id;
+ALTER SEQUENCE public.user_beta_features_id_seq OWNED BY public.user_beta_features.id;
 
 
 --
 -- Name: users; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE users (
+CREATE TABLE public.users (
     id integer NOT NULL,
     name character varying,
     login character varying,
@@ -2131,7 +2118,7 @@ CREATE TABLE users (
 -- Name: users_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE users_id_seq
+CREATE SEQUENCE public.users_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2143,259 +2130,259 @@ CREATE SEQUENCE users_id_seq
 -- Name: users_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE users_id_seq OWNED BY users.id;
+ALTER SEQUENCE public.users_id_seq OWNED BY public.users.id;
 
 
 --
 -- Name: abuses id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY abuses ALTER COLUMN id SET DEFAULT nextval('abuses_id_seq'::regclass);
+ALTER TABLE ONLY public.abuses ALTER COLUMN id SET DEFAULT nextval('public.abuses_id_seq'::regclass);
 
 
 --
 -- Name: beta_features id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY beta_features ALTER COLUMN id SET DEFAULT nextval('beta_features_id_seq'::regclass);
+ALTER TABLE ONLY public.beta_features ALTER COLUMN id SET DEFAULT nextval('public.beta_features_id_seq'::regclass);
 
 
 --
 -- Name: branches id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY branches ALTER COLUMN id SET DEFAULT nextval('branches_id_seq'::regclass);
+ALTER TABLE ONLY public.branches ALTER COLUMN id SET DEFAULT nextval('public.branches_id_seq'::regclass);
 
 
 --
 -- Name: broadcasts id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY broadcasts ALTER COLUMN id SET DEFAULT nextval('broadcasts_id_seq'::regclass);
+ALTER TABLE ONLY public.broadcasts ALTER COLUMN id SET DEFAULT nextval('public.broadcasts_id_seq'::regclass);
 
 
 --
 -- Name: build_configs id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY build_configs ALTER COLUMN id SET DEFAULT nextval('build_configs_id_seq'::regclass);
+ALTER TABLE ONLY public.build_configs ALTER COLUMN id SET DEFAULT nextval('public.build_configs_id_seq'::regclass);
 
 
 --
 -- Name: commits id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY commits ALTER COLUMN id SET DEFAULT nextval('commits_id_seq'::regclass);
+ALTER TABLE ONLY public.commits ALTER COLUMN id SET DEFAULT nextval('public.commits_id_seq'::regclass);
 
 
 --
 -- Name: coupons id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY coupons ALTER COLUMN id SET DEFAULT nextval('coupons_id_seq'::regclass);
+ALTER TABLE ONLY public.coupons ALTER COLUMN id SET DEFAULT nextval('public.coupons_id_seq'::regclass);
 
 
 --
 -- Name: crons id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY crons ALTER COLUMN id SET DEFAULT nextval('crons_id_seq'::regclass);
+ALTER TABLE ONLY public.crons ALTER COLUMN id SET DEFAULT nextval('public.crons_id_seq'::regclass);
 
 
 --
 -- Name: emails id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY emails ALTER COLUMN id SET DEFAULT nextval('emails_id_seq'::regclass);
+ALTER TABLE ONLY public.emails ALTER COLUMN id SET DEFAULT nextval('public.emails_id_seq'::regclass);
 
 
 --
 -- Name: installations id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY installations ALTER COLUMN id SET DEFAULT nextval('installations_id_seq'::regclass);
+ALTER TABLE ONLY public.installations ALTER COLUMN id SET DEFAULT nextval('public.installations_id_seq'::regclass);
 
 
 --
 -- Name: invoices id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY invoices ALTER COLUMN id SET DEFAULT nextval('invoices_id_seq'::regclass);
+ALTER TABLE ONLY public.invoices ALTER COLUMN id SET DEFAULT nextval('public.invoices_id_seq'::regclass);
 
 
 --
 -- Name: job_configs id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY job_configs ALTER COLUMN id SET DEFAULT nextval('job_configs_id_seq'::regclass);
+ALTER TABLE ONLY public.job_configs ALTER COLUMN id SET DEFAULT nextval('public.job_configs_id_seq'::regclass);
 
 
 --
 -- Name: memberships id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY memberships ALTER COLUMN id SET DEFAULT nextval('memberships_id_seq'::regclass);
+ALTER TABLE ONLY public.memberships ALTER COLUMN id SET DEFAULT nextval('public.memberships_id_seq'::regclass);
 
 
 --
 -- Name: messages id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY messages ALTER COLUMN id SET DEFAULT nextval('messages_id_seq'::regclass);
+ALTER TABLE ONLY public.messages ALTER COLUMN id SET DEFAULT nextval('public.messages_id_seq'::regclass);
 
 
 --
 -- Name: organizations id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY organizations ALTER COLUMN id SET DEFAULT nextval('organizations_id_seq'::regclass);
+ALTER TABLE ONLY public.organizations ALTER COLUMN id SET DEFAULT nextval('public.organizations_id_seq'::regclass);
 
 
 --
 -- Name: owner_groups id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY owner_groups ALTER COLUMN id SET DEFAULT nextval('owner_groups_id_seq'::regclass);
+ALTER TABLE ONLY public.owner_groups ALTER COLUMN id SET DEFAULT nextval('public.owner_groups_id_seq'::regclass);
 
 
 --
 -- Name: permissions id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY permissions ALTER COLUMN id SET DEFAULT nextval('permissions_id_seq'::regclass);
+ALTER TABLE ONLY public.permissions ALTER COLUMN id SET DEFAULT nextval('public.permissions_id_seq'::regclass);
 
 
 --
 -- Name: pull_requests id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY pull_requests ALTER COLUMN id SET DEFAULT nextval('pull_requests_id_seq'::regclass);
+ALTER TABLE ONLY public.pull_requests ALTER COLUMN id SET DEFAULT nextval('public.pull_requests_id_seq'::regclass);
 
 
 --
 -- Name: queueable_jobs id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY queueable_jobs ALTER COLUMN id SET DEFAULT nextval('queueable_jobs_id_seq'::regclass);
+ALTER TABLE ONLY public.queueable_jobs ALTER COLUMN id SET DEFAULT nextval('public.queueable_jobs_id_seq'::regclass);
 
 
 --
 -- Name: repositories id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY repositories ALTER COLUMN id SET DEFAULT nextval('repositories_id_seq'::regclass);
+ALTER TABLE ONLY public.repositories ALTER COLUMN id SET DEFAULT nextval('public.repositories_id_seq'::regclass);
 
 
 --
 -- Name: request_configs id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY request_configs ALTER COLUMN id SET DEFAULT nextval('request_configs_id_seq'::regclass);
+ALTER TABLE ONLY public.request_configs ALTER COLUMN id SET DEFAULT nextval('public.request_configs_id_seq'::regclass);
 
 
 --
 -- Name: request_payloads id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY request_payloads ALTER COLUMN id SET DEFAULT nextval('request_payloads_id_seq'::regclass);
+ALTER TABLE ONLY public.request_payloads ALTER COLUMN id SET DEFAULT nextval('public.request_payloads_id_seq'::regclass);
 
 
 --
 -- Name: requests id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY requests ALTER COLUMN id SET DEFAULT nextval('requests_id_seq'::regclass);
+ALTER TABLE ONLY public.requests ALTER COLUMN id SET DEFAULT nextval('public.requests_id_seq'::regclass);
 
 
 --
 -- Name: ssl_keys id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY ssl_keys ALTER COLUMN id SET DEFAULT nextval('ssl_keys_id_seq'::regclass);
+ALTER TABLE ONLY public.ssl_keys ALTER COLUMN id SET DEFAULT nextval('public.ssl_keys_id_seq'::regclass);
 
 
 --
 -- Name: stages id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY stages ALTER COLUMN id SET DEFAULT nextval('stages_id_seq'::regclass);
+ALTER TABLE ONLY public.stages ALTER COLUMN id SET DEFAULT nextval('public.stages_id_seq'::regclass);
 
 
 --
 -- Name: stars id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY stars ALTER COLUMN id SET DEFAULT nextval('stars_id_seq'::regclass);
+ALTER TABLE ONLY public.stars ALTER COLUMN id SET DEFAULT nextval('public.stars_id_seq'::regclass);
 
 
 --
 -- Name: stripe_events id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY stripe_events ALTER COLUMN id SET DEFAULT nextval('stripe_events_id_seq'::regclass);
+ALTER TABLE ONLY public.stripe_events ALTER COLUMN id SET DEFAULT nextval('public.stripe_events_id_seq'::regclass);
 
 
 --
 -- Name: subscriptions id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY subscriptions ALTER COLUMN id SET DEFAULT nextval('subscriptions_id_seq'::regclass);
+ALTER TABLE ONLY public.subscriptions ALTER COLUMN id SET DEFAULT nextval('public.subscriptions_id_seq'::regclass);
 
 
 --
 -- Name: tags id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY tags ALTER COLUMN id SET DEFAULT nextval('tags_id_seq'::regclass);
+ALTER TABLE ONLY public.tags ALTER COLUMN id SET DEFAULT nextval('public.tags_id_seq'::regclass);
 
 
 --
 -- Name: tokens id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY tokens ALTER COLUMN id SET DEFAULT nextval('tokens_id_seq'::regclass);
+ALTER TABLE ONLY public.tokens ALTER COLUMN id SET DEFAULT nextval('public.tokens_id_seq'::regclass);
 
 
 --
 -- Name: trial_allowances id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY trial_allowances ALTER COLUMN id SET DEFAULT nextval('trial_allowances_id_seq'::regclass);
+ALTER TABLE ONLY public.trial_allowances ALTER COLUMN id SET DEFAULT nextval('public.trial_allowances_id_seq'::regclass);
 
 
 --
 -- Name: trials id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY trials ALTER COLUMN id SET DEFAULT nextval('trials_id_seq'::regclass);
+ALTER TABLE ONLY public.trials ALTER COLUMN id SET DEFAULT nextval('public.trials_id_seq'::regclass);
 
 
 --
 -- Name: urls id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY urls ALTER COLUMN id SET DEFAULT nextval('urls_id_seq'::regclass);
+ALTER TABLE ONLY public.urls ALTER COLUMN id SET DEFAULT nextval('public.urls_id_seq'::regclass);
 
 
 --
 -- Name: user_beta_features id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY user_beta_features ALTER COLUMN id SET DEFAULT nextval('user_beta_features_id_seq'::regclass);
+ALTER TABLE ONLY public.user_beta_features ALTER COLUMN id SET DEFAULT nextval('public.user_beta_features_id_seq'::regclass);
 
 
 --
 -- Name: users id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY users ALTER COLUMN id SET DEFAULT nextval('users_id_seq'::regclass);
+ALTER TABLE ONLY public.users ALTER COLUMN id SET DEFAULT nextval('public.users_id_seq'::regclass);
 
 
 --
 -- Name: abuses abuses_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY abuses
+ALTER TABLE ONLY public.abuses
     ADD CONSTRAINT abuses_pkey PRIMARY KEY (id);
 
 
@@ -2403,7 +2390,7 @@ ALTER TABLE ONLY abuses
 -- Name: ar_internal_metadata ar_internal_metadata_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY ar_internal_metadata
+ALTER TABLE ONLY public.ar_internal_metadata
     ADD CONSTRAINT ar_internal_metadata_pkey PRIMARY KEY (key);
 
 
@@ -2411,7 +2398,7 @@ ALTER TABLE ONLY ar_internal_metadata
 -- Name: beta_features beta_features_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY beta_features
+ALTER TABLE ONLY public.beta_features
     ADD CONSTRAINT beta_features_pkey PRIMARY KEY (id);
 
 
@@ -2419,7 +2406,7 @@ ALTER TABLE ONLY beta_features
 -- Name: branches branches_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY branches
+ALTER TABLE ONLY public.branches
     ADD CONSTRAINT branches_pkey PRIMARY KEY (id);
 
 
@@ -2427,7 +2414,7 @@ ALTER TABLE ONLY branches
 -- Name: broadcasts broadcasts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY broadcasts
+ALTER TABLE ONLY public.broadcasts
     ADD CONSTRAINT broadcasts_pkey PRIMARY KEY (id);
 
 
@@ -2435,7 +2422,7 @@ ALTER TABLE ONLY broadcasts
 -- Name: build_configs build_configs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY build_configs
+ALTER TABLE ONLY public.build_configs
     ADD CONSTRAINT build_configs_pkey PRIMARY KEY (id);
 
 
@@ -2443,7 +2430,7 @@ ALTER TABLE ONLY build_configs
 -- Name: builds builds_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY builds
+ALTER TABLE ONLY public.builds
     ADD CONSTRAINT builds_pkey PRIMARY KEY (id);
 
 
@@ -2451,7 +2438,7 @@ ALTER TABLE ONLY builds
 -- Name: commits commits_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY commits
+ALTER TABLE ONLY public.commits
     ADD CONSTRAINT commits_pkey PRIMARY KEY (id);
 
 
@@ -2459,7 +2446,7 @@ ALTER TABLE ONLY commits
 -- Name: coupons coupons_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY coupons
+ALTER TABLE ONLY public.coupons
     ADD CONSTRAINT coupons_pkey PRIMARY KEY (id);
 
 
@@ -2467,7 +2454,7 @@ ALTER TABLE ONLY coupons
 -- Name: crons crons_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY crons
+ALTER TABLE ONLY public.crons
     ADD CONSTRAINT crons_pkey PRIMARY KEY (id);
 
 
@@ -2475,7 +2462,7 @@ ALTER TABLE ONLY crons
 -- Name: emails emails_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY emails
+ALTER TABLE ONLY public.emails
     ADD CONSTRAINT emails_pkey PRIMARY KEY (id);
 
 
@@ -2483,7 +2470,7 @@ ALTER TABLE ONLY emails
 -- Name: installations installations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY installations
+ALTER TABLE ONLY public.installations
     ADD CONSTRAINT installations_pkey PRIMARY KEY (id);
 
 
@@ -2491,7 +2478,7 @@ ALTER TABLE ONLY installations
 -- Name: invoices invoices_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY invoices
+ALTER TABLE ONLY public.invoices
     ADD CONSTRAINT invoices_pkey PRIMARY KEY (id);
 
 
@@ -2499,7 +2486,7 @@ ALTER TABLE ONLY invoices
 -- Name: job_configs job_configs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY job_configs
+ALTER TABLE ONLY public.job_configs
     ADD CONSTRAINT job_configs_pkey PRIMARY KEY (id);
 
 
@@ -2507,7 +2494,7 @@ ALTER TABLE ONLY job_configs
 -- Name: jobs jobs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY jobs
+ALTER TABLE ONLY public.jobs
     ADD CONSTRAINT jobs_pkey PRIMARY KEY (id);
 
 
@@ -2515,7 +2502,7 @@ ALTER TABLE ONLY jobs
 -- Name: memberships memberships_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY memberships
+ALTER TABLE ONLY public.memberships
     ADD CONSTRAINT memberships_pkey PRIMARY KEY (id);
 
 
@@ -2523,7 +2510,7 @@ ALTER TABLE ONLY memberships
 -- Name: messages messages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY messages
+ALTER TABLE ONLY public.messages
     ADD CONSTRAINT messages_pkey PRIMARY KEY (id);
 
 
@@ -2531,7 +2518,7 @@ ALTER TABLE ONLY messages
 -- Name: organizations organizations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY organizations
+ALTER TABLE ONLY public.organizations
     ADD CONSTRAINT organizations_pkey PRIMARY KEY (id);
 
 
@@ -2539,7 +2526,7 @@ ALTER TABLE ONLY organizations
 -- Name: owner_groups owner_groups_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY owner_groups
+ALTER TABLE ONLY public.owner_groups
     ADD CONSTRAINT owner_groups_pkey PRIMARY KEY (id);
 
 
@@ -2547,7 +2534,7 @@ ALTER TABLE ONLY owner_groups
 -- Name: permissions permissions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY permissions
+ALTER TABLE ONLY public.permissions
     ADD CONSTRAINT permissions_pkey PRIMARY KEY (id);
 
 
@@ -2555,7 +2542,7 @@ ALTER TABLE ONLY permissions
 -- Name: pull_requests pull_requests_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY pull_requests
+ALTER TABLE ONLY public.pull_requests
     ADD CONSTRAINT pull_requests_pkey PRIMARY KEY (id);
 
 
@@ -2563,7 +2550,7 @@ ALTER TABLE ONLY pull_requests
 -- Name: queueable_jobs queueable_jobs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY queueable_jobs
+ALTER TABLE ONLY public.queueable_jobs
     ADD CONSTRAINT queueable_jobs_pkey PRIMARY KEY (id);
 
 
@@ -2571,7 +2558,7 @@ ALTER TABLE ONLY queueable_jobs
 -- Name: repositories repositories_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY repositories
+ALTER TABLE ONLY public.repositories
     ADD CONSTRAINT repositories_pkey PRIMARY KEY (id);
 
 
@@ -2579,7 +2566,7 @@ ALTER TABLE ONLY repositories
 -- Name: request_configs request_configs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY request_configs
+ALTER TABLE ONLY public.request_configs
     ADD CONSTRAINT request_configs_pkey PRIMARY KEY (id);
 
 
@@ -2587,7 +2574,7 @@ ALTER TABLE ONLY request_configs
 -- Name: request_payloads request_payloads_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY request_payloads
+ALTER TABLE ONLY public.request_payloads
     ADD CONSTRAINT request_payloads_pkey PRIMARY KEY (id);
 
 
@@ -2595,23 +2582,15 @@ ALTER TABLE ONLY request_payloads
 -- Name: requests requests_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY requests
+ALTER TABLE ONLY public.requests
     ADD CONSTRAINT requests_pkey PRIMARY KEY (id);
-
-
---
--- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY schema_migrations
-    ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
 
 
 --
 -- Name: ssl_keys ssl_keys_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY ssl_keys
+ALTER TABLE ONLY public.ssl_keys
     ADD CONSTRAINT ssl_keys_pkey PRIMARY KEY (id);
 
 
@@ -2619,7 +2598,7 @@ ALTER TABLE ONLY ssl_keys
 -- Name: stages stages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY stages
+ALTER TABLE ONLY public.stages
     ADD CONSTRAINT stages_pkey PRIMARY KEY (id);
 
 
@@ -2627,7 +2606,7 @@ ALTER TABLE ONLY stages
 -- Name: stars stars_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY stars
+ALTER TABLE ONLY public.stars
     ADD CONSTRAINT stars_pkey PRIMARY KEY (id);
 
 
@@ -2635,7 +2614,7 @@ ALTER TABLE ONLY stars
 -- Name: stripe_events stripe_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY stripe_events
+ALTER TABLE ONLY public.stripe_events
     ADD CONSTRAINT stripe_events_pkey PRIMARY KEY (id);
 
 
@@ -2643,7 +2622,7 @@ ALTER TABLE ONLY stripe_events
 -- Name: subscriptions subscriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY subscriptions
+ALTER TABLE ONLY public.subscriptions
     ADD CONSTRAINT subscriptions_pkey PRIMARY KEY (id);
 
 
@@ -2651,7 +2630,7 @@ ALTER TABLE ONLY subscriptions
 -- Name: tags tags_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY tags
+ALTER TABLE ONLY public.tags
     ADD CONSTRAINT tags_pkey PRIMARY KEY (id);
 
 
@@ -2659,7 +2638,7 @@ ALTER TABLE ONLY tags
 -- Name: tokens tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY tokens
+ALTER TABLE ONLY public.tokens
     ADD CONSTRAINT tokens_pkey PRIMARY KEY (id);
 
 
@@ -2667,7 +2646,7 @@ ALTER TABLE ONLY tokens
 -- Name: trial_allowances trial_allowances_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY trial_allowances
+ALTER TABLE ONLY public.trial_allowances
     ADD CONSTRAINT trial_allowances_pkey PRIMARY KEY (id);
 
 
@@ -2675,7 +2654,7 @@ ALTER TABLE ONLY trial_allowances
 -- Name: trials trials_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY trials
+ALTER TABLE ONLY public.trials
     ADD CONSTRAINT trials_pkey PRIMARY KEY (id);
 
 
@@ -2683,7 +2662,7 @@ ALTER TABLE ONLY trials
 -- Name: urls urls_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY urls
+ALTER TABLE ONLY public.urls
     ADD CONSTRAINT urls_pkey PRIMARY KEY (id);
 
 
@@ -2691,7 +2670,7 @@ ALTER TABLE ONLY urls
 -- Name: user_beta_features user_beta_features_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY user_beta_features
+ALTER TABLE ONLY public.user_beta_features
     ADD CONSTRAINT user_beta_features_pkey PRIMARY KEY (id);
 
 
@@ -2699,7 +2678,7 @@ ALTER TABLE ONLY user_beta_features
 -- Name: users users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY users
+ALTER TABLE ONLY public.users
     ADD CONSTRAINT users_pkey PRIMARY KEY (id);
 
 
@@ -2707,912 +2686,919 @@ ALTER TABLE ONLY users
 -- Name: github_id_installations_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX github_id_installations_idx ON installations USING btree (github_id);
+CREATE UNIQUE INDEX github_id_installations_idx ON public.installations USING btree (github_id);
 
 
 --
 -- Name: index_abuses_on_owner; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_abuses_on_owner ON abuses USING btree (owner_id);
+CREATE INDEX index_abuses_on_owner ON public.abuses USING btree (owner_id);
 
 
 --
 -- Name: index_abuses_on_owner_id_and_owner_type_and_level; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_abuses_on_owner_id_and_owner_type_and_level ON abuses USING btree (owner_id, owner_type, level);
+CREATE UNIQUE INDEX index_abuses_on_owner_id_and_owner_type_and_level ON public.abuses USING btree (owner_id, owner_type, level);
 
 
 --
 -- Name: index_branches_on_com_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_branches_on_com_id ON branches USING btree (com_id);
+CREATE UNIQUE INDEX index_branches_on_com_id ON public.branches USING btree (com_id);
 
 
 --
 -- Name: index_branches_on_org_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_branches_on_org_id ON branches USING btree (org_id);
+CREATE UNIQUE INDEX index_branches_on_org_id ON public.branches USING btree (org_id);
 
 
 --
 -- Name: index_branches_on_repository_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_branches_on_repository_id ON branches USING btree (repository_id);
+CREATE INDEX index_branches_on_repository_id ON public.branches USING btree (repository_id);
 
 
 --
 -- Name: index_branches_on_repository_id_and_name_and_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_branches_on_repository_id_and_name_and_id ON branches USING btree (repository_id, name, id);
+CREATE INDEX index_branches_on_repository_id_and_name_and_id ON public.branches USING btree (repository_id, name, id);
 
 
 --
 -- Name: index_broadcasts_on_recipient_id_and_recipient_type; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_broadcasts_on_recipient_id_and_recipient_type ON broadcasts USING btree (recipient_id, recipient_type);
+CREATE INDEX index_broadcasts_on_recipient_id_and_recipient_type ON public.broadcasts USING btree (recipient_id, recipient_type);
 
 
 --
 -- Name: index_build_configs_on_repository_id_and_key; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_build_configs_on_repository_id_and_key ON build_configs USING btree (repository_id, key);
+CREATE INDEX index_build_configs_on_repository_id_and_key ON public.build_configs USING btree (repository_id, key);
 
 
 --
 -- Name: index_builds_on_com_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_builds_on_com_id ON builds USING btree (com_id);
+CREATE UNIQUE INDEX index_builds_on_com_id ON public.builds USING btree (com_id);
 
 
 --
 -- Name: index_builds_on_org_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_builds_on_org_id ON builds USING btree (org_id);
+CREATE UNIQUE INDEX index_builds_on_org_id ON public.builds USING btree (org_id);
 
 
 --
 -- Name: index_builds_on_repository_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_builds_on_repository_id ON builds USING btree (repository_id);
+CREATE INDEX index_builds_on_repository_id ON public.builds USING btree (repository_id);
 
 
 --
 -- Name: index_builds_on_repository_id_and_branch_and_event_type; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_builds_on_repository_id_and_branch_and_event_type ON builds USING btree (repository_id, branch, event_type) WHERE ((state)::text = ANY ((ARRAY['created'::character varying, 'queued'::character varying, 'received'::character varying])::text[]));
+CREATE INDEX index_builds_on_repository_id_and_branch_and_event_type ON public.builds USING btree (repository_id, branch, event_type) WHERE ((state)::text = ANY ((ARRAY['created'::character varying, 'queued'::character varying, 'received'::character varying])::text[]));
 
 
 --
 -- Name: index_builds_on_repository_id_and_branch_and_event_type_and_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_builds_on_repository_id_and_branch_and_event_type_and_id ON builds USING btree (repository_id, branch, event_type, id);
+CREATE INDEX index_builds_on_repository_id_and_branch_and_event_type_and_id ON public.builds USING btree (repository_id, branch, event_type, id);
 
 
 --
 -- Name: index_builds_on_repository_id_and_branch_and_id_desc; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_builds_on_repository_id_and_branch_and_id_desc ON builds USING btree (repository_id, branch, id DESC);
+CREATE INDEX index_builds_on_repository_id_and_branch_and_id_desc ON public.builds USING btree (repository_id, branch, id DESC);
 
 
 --
 -- Name: index_builds_on_repository_id_and_number; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_builds_on_repository_id_and_number ON builds USING btree (repository_id, ((number)::integer));
+CREATE INDEX index_builds_on_repository_id_and_number ON public.builds USING btree (repository_id, ((number)::integer));
 
 
 --
 -- Name: index_builds_on_repository_id_and_number_and_event_type; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_builds_on_repository_id_and_number_and_event_type ON builds USING btree (repository_id, number, event_type);
+CREATE INDEX index_builds_on_repository_id_and_number_and_event_type ON public.builds USING btree (repository_id, number, event_type);
 
 
 --
 -- Name: index_builds_on_repository_id_where_state_not_finished; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_builds_on_repository_id_where_state_not_finished ON builds USING btree (repository_id) WHERE ((state)::text = ANY ((ARRAY['created'::character varying, 'queued'::character varying, 'received'::character varying, 'started'::character varying])::text[]));
+CREATE INDEX index_builds_on_repository_id_where_state_not_finished ON public.builds USING btree (repository_id) WHERE ((state)::text = ANY ((ARRAY['created'::character varying, 'queued'::character varying, 'received'::character varying, 'started'::character varying])::text[]));
 
 
 --
 -- Name: index_builds_on_request_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_builds_on_request_id ON builds USING btree (request_id);
+CREATE INDEX index_builds_on_request_id ON public.builds USING btree (request_id);
 
 
 --
 -- Name: index_builds_on_sender_type_and_sender_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_builds_on_sender_type_and_sender_id ON builds USING btree (sender_type, sender_id);
+CREATE INDEX index_builds_on_sender_type_and_sender_id ON public.builds USING btree (sender_type, sender_id);
 
 
 --
 -- Name: index_builds_on_state; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_builds_on_state ON builds USING btree (state);
+CREATE INDEX index_builds_on_state ON public.builds USING btree (state);
 
 
 --
 -- Name: index_builds_on_updated_at; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_builds_on_updated_at ON builds USING btree (updated_at);
+CREATE INDEX index_builds_on_updated_at ON public.builds USING btree (updated_at);
 
 
 --
 -- Name: index_commits_on_com_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_commits_on_com_id ON commits USING btree (com_id);
+CREATE UNIQUE INDEX index_commits_on_com_id ON public.commits USING btree (com_id);
 
 
 --
 -- Name: index_commits_on_org_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_commits_on_org_id ON commits USING btree (org_id);
+CREATE UNIQUE INDEX index_commits_on_org_id ON public.commits USING btree (org_id);
 
 
 --
 -- Name: index_crons_on_com_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_crons_on_com_id ON crons USING btree (com_id);
+CREATE UNIQUE INDEX index_crons_on_com_id ON public.crons USING btree (com_id);
 
 
 --
 -- Name: index_crons_on_org_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_crons_on_org_id ON crons USING btree (org_id);
+CREATE UNIQUE INDEX index_crons_on_org_id ON public.crons USING btree (org_id);
 
 
 --
 -- Name: index_emails_on_email; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_emails_on_email ON emails USING btree (email);
+CREATE INDEX index_emails_on_email ON public.emails USING btree (email);
 
 
 --
 -- Name: index_emails_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_emails_on_user_id ON emails USING btree (user_id);
+CREATE INDEX index_emails_on_user_id ON public.emails USING btree (user_id);
 
 
 --
 -- Name: index_installations_on_owner_type_and_owner_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_installations_on_owner_type_and_owner_id ON installations USING btree (owner_type, owner_id);
+CREATE INDEX index_installations_on_owner_type_and_owner_id ON public.installations USING btree (owner_type, owner_id);
 
 
 --
 -- Name: index_invoices_on_stripe_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_invoices_on_stripe_id ON invoices USING btree (stripe_id);
+CREATE INDEX index_invoices_on_stripe_id ON public.invoices USING btree (stripe_id);
 
 
 --
 -- Name: index_job_configs_on_repository_id_and_key; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_job_configs_on_repository_id_and_key ON job_configs USING btree (repository_id, key);
+CREATE INDEX index_job_configs_on_repository_id_and_key ON public.job_configs USING btree (repository_id, key);
 
 
 --
 -- Name: index_jobs_on_com_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_jobs_on_com_id ON jobs USING btree (com_id);
+CREATE UNIQUE INDEX index_jobs_on_com_id ON public.jobs USING btree (com_id);
 
 
 --
 -- Name: index_jobs_on_created_at; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_jobs_on_created_at ON jobs USING btree (created_at);
+CREATE INDEX index_jobs_on_created_at ON public.jobs USING btree (created_at);
 
 
 --
 -- Name: index_jobs_on_org_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_jobs_on_org_id ON jobs USING btree (org_id);
+CREATE UNIQUE INDEX index_jobs_on_org_id ON public.jobs USING btree (org_id);
 
 
 --
 -- Name: index_jobs_on_owner_id_and_owner_type_and_state; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_jobs_on_owner_id_and_owner_type_and_state ON jobs USING btree (owner_id, owner_type, state);
+CREATE INDEX index_jobs_on_owner_id_and_owner_type_and_state ON public.jobs USING btree (owner_id, owner_type, state);
 
 
 --
 -- Name: index_jobs_on_repository_id_where_state_running; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_jobs_on_repository_id_where_state_running ON jobs USING btree (repository_id) WHERE ((state)::text = ANY ((ARRAY['queued'::character varying, 'received'::character varying, 'started'::character varying])::text[]));
+CREATE INDEX index_jobs_on_repository_id_where_state_running ON public.jobs USING btree (repository_id) WHERE ((state)::text = ANY ((ARRAY['queued'::character varying, 'received'::character varying, 'started'::character varying])::text[]));
 
 
 --
 -- Name: index_jobs_on_source_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_jobs_on_source_id ON jobs USING btree (source_id);
+CREATE INDEX index_jobs_on_source_id ON public.jobs USING btree (source_id);
 
 
 --
 -- Name: index_jobs_on_stage_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_jobs_on_stage_id ON jobs USING btree (stage_id);
+CREATE INDEX index_jobs_on_stage_id ON public.jobs USING btree (stage_id);
 
 
 --
 -- Name: index_jobs_on_state; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_jobs_on_state ON jobs USING btree (state);
+CREATE INDEX index_jobs_on_state ON public.jobs USING btree (state);
 
 
 --
 -- Name: index_jobs_on_type_and_source_id_and_source_type; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_jobs_on_type_and_source_id_and_source_type ON jobs USING btree (type, source_id, source_type);
+CREATE INDEX index_jobs_on_type_and_source_id_and_source_type ON public.jobs USING btree (type, source_id, source_type);
 
 
 --
 -- Name: index_jobs_on_updated_at; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_jobs_on_updated_at ON jobs USING btree (updated_at);
+CREATE INDEX index_jobs_on_updated_at ON public.jobs USING btree (updated_at);
 
 
 --
 -- Name: index_memberships_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_memberships_on_user_id ON memberships USING btree (user_id);
+CREATE INDEX index_memberships_on_user_id ON public.memberships USING btree (user_id);
 
 
 --
 -- Name: index_messages_on_subject_type_and_subject_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_messages_on_subject_type_and_subject_id ON messages USING btree (subject_type, subject_id);
+CREATE INDEX index_messages_on_subject_type_and_subject_id ON public.messages USING btree (subject_type, subject_id);
 
 
 --
 -- Name: index_organizations_on_com_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_organizations_on_com_id ON organizations USING btree (com_id);
+CREATE UNIQUE INDEX index_organizations_on_com_id ON public.organizations USING btree (com_id);
 
 
 --
 -- Name: index_organizations_on_github_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_organizations_on_github_id ON organizations USING btree (github_id);
+CREATE UNIQUE INDEX index_organizations_on_github_id ON public.organizations USING btree (github_id);
 
 
 --
 -- Name: index_organizations_on_login; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_organizations_on_login ON organizations USING btree (login);
+CREATE INDEX index_organizations_on_login ON public.organizations USING btree (login);
 
 
 --
 -- Name: index_organizations_on_lower_login; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_organizations_on_lower_login ON organizations USING btree (lower((login)::text));
+CREATE INDEX index_organizations_on_lower_login ON public.organizations USING btree (lower((login)::text));
 
 
 --
 -- Name: index_organizations_on_org_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_organizations_on_org_id ON organizations USING btree (org_id);
+CREATE UNIQUE INDEX index_organizations_on_org_id ON public.organizations USING btree (org_id);
 
 
 --
 -- Name: index_organizations_on_updated_at; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_organizations_on_updated_at ON organizations USING btree (updated_at);
+CREATE INDEX index_organizations_on_updated_at ON public.organizations USING btree (updated_at);
 
 
 --
 -- Name: index_owner_groups_on_owner_type_and_owner_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_owner_groups_on_owner_type_and_owner_id ON owner_groups USING btree (owner_type, owner_id);
+CREATE INDEX index_owner_groups_on_owner_type_and_owner_id ON public.owner_groups USING btree (owner_type, owner_id);
 
 
 --
 -- Name: index_owner_groups_on_uuid; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_owner_groups_on_uuid ON owner_groups USING btree (uuid);
+CREATE INDEX index_owner_groups_on_uuid ON public.owner_groups USING btree (uuid);
 
 
 --
 -- Name: index_permissions_on_com_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_permissions_on_com_id ON permissions USING btree (com_id);
+CREATE UNIQUE INDEX index_permissions_on_com_id ON public.permissions USING btree (com_id);
 
 
 --
 -- Name: index_permissions_on_org_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_permissions_on_org_id ON permissions USING btree (org_id);
+CREATE UNIQUE INDEX index_permissions_on_org_id ON public.permissions USING btree (org_id);
 
 
 --
 -- Name: index_permissions_on_repository_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_permissions_on_repository_id ON permissions USING btree (repository_id);
+CREATE INDEX index_permissions_on_repository_id ON public.permissions USING btree (repository_id);
 
 
 --
 -- Name: index_permissions_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_permissions_on_user_id ON permissions USING btree (user_id);
+CREATE INDEX index_permissions_on_user_id ON public.permissions USING btree (user_id);
 
 
 --
 -- Name: index_permissions_on_user_id_and_repository_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_permissions_on_user_id_and_repository_id ON permissions USING btree (user_id, repository_id);
+CREATE UNIQUE INDEX index_permissions_on_user_id_and_repository_id ON public.permissions USING btree (user_id, repository_id);
 
 
 --
 -- Name: index_pull_requests_on_com_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_pull_requests_on_com_id ON pull_requests USING btree (com_id);
+CREATE UNIQUE INDEX index_pull_requests_on_com_id ON public.pull_requests USING btree (com_id);
 
 
 --
 -- Name: index_pull_requests_on_org_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_pull_requests_on_org_id ON pull_requests USING btree (org_id);
+CREATE UNIQUE INDEX index_pull_requests_on_org_id ON public.pull_requests USING btree (org_id);
 
 
 --
 -- Name: index_pull_requests_on_repository_id_and_number; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_pull_requests_on_repository_id_and_number ON pull_requests USING btree (repository_id, number);
+CREATE UNIQUE INDEX index_pull_requests_on_repository_id_and_number ON public.pull_requests USING btree (repository_id, number);
 
 
 --
 -- Name: index_queueable_jobs_on_job_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_queueable_jobs_on_job_id ON queueable_jobs USING btree (job_id);
+CREATE INDEX index_queueable_jobs_on_job_id ON public.queueable_jobs USING btree (job_id);
 
 
 --
 -- Name: index_repo_counts_on_repository_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_repo_counts_on_repository_id ON repo_counts USING btree (repository_id);
+CREATE INDEX index_repo_counts_on_repository_id ON public.repo_counts USING btree (repository_id);
 
 
 --
 -- Name: index_repositories_on_active; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_repositories_on_active ON repositories USING btree (active);
+CREATE INDEX index_repositories_on_active ON public.repositories USING btree (active);
 
 
 --
 -- Name: index_repositories_on_com_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_repositories_on_com_id ON repositories USING btree (com_id);
+CREATE UNIQUE INDEX index_repositories_on_com_id ON public.repositories USING btree (com_id);
 
 
 --
 -- Name: index_repositories_on_github_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_repositories_on_github_id ON repositories USING btree (github_id);
+CREATE UNIQUE INDEX index_repositories_on_github_id ON public.repositories USING btree (github_id);
 
 
 --
 -- Name: index_repositories_on_lower_name; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_repositories_on_lower_name ON repositories USING btree (lower((name)::text));
+CREATE INDEX index_repositories_on_lower_name ON public.repositories USING btree (lower((name)::text));
 
 
 --
 -- Name: index_repositories_on_name; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_repositories_on_name ON repositories USING btree (name);
+CREATE INDEX index_repositories_on_name ON public.repositories USING btree (name);
 
 
 --
 -- Name: index_repositories_on_org_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_repositories_on_org_id ON repositories USING btree (org_id);
+CREATE UNIQUE INDEX index_repositories_on_org_id ON public.repositories USING btree (org_id);
 
 
 --
 -- Name: index_repositories_on_owner_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_repositories_on_owner_id ON repositories USING btree (owner_id);
+CREATE INDEX index_repositories_on_owner_id ON public.repositories USING btree (owner_id);
 
 
 --
 -- Name: index_repositories_on_owner_name; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_repositories_on_owner_name ON repositories USING btree (owner_name);
+CREATE INDEX index_repositories_on_owner_name ON public.repositories USING btree (owner_name);
 
 
 --
 -- Name: index_repositories_on_slug; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_repositories_on_slug ON repositories USING gin (((((owner_name)::text || '/'::text) || (name)::text)) gin_trgm_ops);
+CREATE INDEX index_repositories_on_slug ON public.repositories USING gin (((((owner_name)::text || '/'::text) || (name)::text)) public.gin_trgm_ops);
 
 
 --
 -- Name: index_repositories_on_updated_at; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_repositories_on_updated_at ON repositories USING btree (updated_at);
+CREATE INDEX index_repositories_on_updated_at ON public.repositories USING btree (updated_at);
 
 
 --
 -- Name: index_request_configs_on_repository_id_and_key; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_request_configs_on_repository_id_and_key ON request_configs USING btree (repository_id, key);
+CREATE INDEX index_request_configs_on_repository_id_and_key ON public.request_configs USING btree (repository_id, key);
 
 
 --
 -- Name: index_request_payloads_on_created_at_and_archived; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_request_payloads_on_created_at_and_archived ON request_payloads USING btree (created_at, archived);
+CREATE INDEX index_request_payloads_on_created_at_and_archived ON public.request_payloads USING btree (created_at, archived);
 
 
 --
 -- Name: index_request_payloads_on_request_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_request_payloads_on_request_id ON request_payloads USING btree (request_id);
+CREATE INDEX index_request_payloads_on_request_id ON public.request_payloads USING btree (request_id);
 
 
 --
 -- Name: index_requests_on_com_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_requests_on_com_id ON requests USING btree (com_id);
+CREATE UNIQUE INDEX index_requests_on_com_id ON public.requests USING btree (com_id);
 
 
 --
 -- Name: index_requests_on_commit_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_requests_on_commit_id ON requests USING btree (commit_id);
+CREATE INDEX index_requests_on_commit_id ON public.requests USING btree (commit_id);
 
 
 --
 -- Name: index_requests_on_created_at; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_requests_on_created_at ON requests USING btree (created_at);
+CREATE INDEX index_requests_on_created_at ON public.requests USING btree (created_at);
 
 
 --
 -- Name: index_requests_on_head_commit; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_requests_on_head_commit ON requests USING btree (head_commit);
+CREATE INDEX index_requests_on_head_commit ON public.requests USING btree (head_commit);
 
 
 --
 -- Name: index_requests_on_org_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_requests_on_org_id ON requests USING btree (org_id);
+CREATE UNIQUE INDEX index_requests_on_org_id ON public.requests USING btree (org_id);
 
 
 --
 -- Name: index_requests_on_repository_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_requests_on_repository_id ON requests USING btree (repository_id);
+CREATE INDEX index_requests_on_repository_id ON public.requests USING btree (repository_id);
 
 
 --
 -- Name: index_requests_on_repository_id_and_id_desc; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_requests_on_repository_id_and_id_desc ON requests USING btree (repository_id, id DESC);
+CREATE INDEX index_requests_on_repository_id_and_id_desc ON public.requests USING btree (repository_id, id DESC);
 
 
 --
 -- Name: index_ssl_key_on_repository_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_ssl_key_on_repository_id ON ssl_keys USING btree (repository_id);
+CREATE INDEX index_ssl_key_on_repository_id ON public.ssl_keys USING btree (repository_id);
 
 
 --
 -- Name: index_ssl_keys_on_com_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_ssl_keys_on_com_id ON ssl_keys USING btree (com_id);
+CREATE UNIQUE INDEX index_ssl_keys_on_com_id ON public.ssl_keys USING btree (com_id);
 
 
 --
 -- Name: index_ssl_keys_on_org_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_ssl_keys_on_org_id ON ssl_keys USING btree (org_id);
+CREATE UNIQUE INDEX index_ssl_keys_on_org_id ON public.ssl_keys USING btree (org_id);
 
 
 --
 -- Name: index_stages_on_build_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_stages_on_build_id ON stages USING btree (build_id);
+CREATE INDEX index_stages_on_build_id ON public.stages USING btree (build_id);
 
 
 --
 -- Name: index_stages_on_com_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_stages_on_com_id ON stages USING btree (com_id);
+CREATE UNIQUE INDEX index_stages_on_com_id ON public.stages USING btree (com_id);
 
 
 --
 -- Name: index_stages_on_org_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_stages_on_org_id ON stages USING btree (org_id);
+CREATE UNIQUE INDEX index_stages_on_org_id ON public.stages USING btree (org_id);
 
 
 --
 -- Name: index_stars_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_stars_on_user_id ON stars USING btree (user_id);
+CREATE INDEX index_stars_on_user_id ON public.stars USING btree (user_id);
 
 
 --
 -- Name: index_stars_on_user_id_and_repository_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_stars_on_user_id_and_repository_id ON stars USING btree (user_id, repository_id);
+CREATE UNIQUE INDEX index_stars_on_user_id_and_repository_id ON public.stars USING btree (user_id, repository_id);
 
 
 --
 -- Name: index_stripe_events_on_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_stripe_events_on_date ON stripe_events USING btree (date);
+CREATE INDEX index_stripe_events_on_date ON public.stripe_events USING btree (date);
 
 
 --
 -- Name: index_stripe_events_on_event_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_stripe_events_on_event_id ON stripe_events USING btree (event_id);
+CREATE INDEX index_stripe_events_on_event_id ON public.stripe_events USING btree (event_id);
 
 
 --
 -- Name: index_stripe_events_on_event_type; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_stripe_events_on_event_type ON stripe_events USING btree (event_type);
+CREATE INDEX index_stripe_events_on_event_type ON public.stripe_events USING btree (event_type);
 
 
 --
 -- Name: index_tags_on_com_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_tags_on_com_id ON tags USING btree (com_id);
+CREATE UNIQUE INDEX index_tags_on_com_id ON public.tags USING btree (com_id);
 
 
 --
 -- Name: index_tags_on_org_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_tags_on_org_id ON tags USING btree (org_id);
+CREATE UNIQUE INDEX index_tags_on_org_id ON public.tags USING btree (org_id);
 
 
 --
 -- Name: index_tags_on_repository_id_and_name; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_tags_on_repository_id_and_name ON tags USING btree (repository_id, name);
+CREATE UNIQUE INDEX index_tags_on_repository_id_and_name ON public.tags USING btree (repository_id, name);
 
 
 --
 -- Name: index_tokens_on_token; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_tokens_on_token ON tokens USING btree (token);
+CREATE INDEX index_tokens_on_token ON public.tokens USING btree (token);
 
 
 --
 -- Name: index_tokens_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_tokens_on_user_id ON tokens USING btree (user_id);
+CREATE INDEX index_tokens_on_user_id ON public.tokens USING btree (user_id);
 
 
 --
 -- Name: index_trial_allowances_on_creator_id_and_creator_type; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_trial_allowances_on_creator_id_and_creator_type ON trial_allowances USING btree (creator_id, creator_type);
+CREATE INDEX index_trial_allowances_on_creator_id_and_creator_type ON public.trial_allowances USING btree (creator_id, creator_type);
 
 
 --
 -- Name: index_trial_allowances_on_trial_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_trial_allowances_on_trial_id ON trial_allowances USING btree (trial_id);
+CREATE INDEX index_trial_allowances_on_trial_id ON public.trial_allowances USING btree (trial_id);
 
 
 --
 -- Name: index_trials_on_owner; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_trials_on_owner ON trials USING btree (owner_id, owner_type);
+CREATE INDEX index_trials_on_owner ON public.trials USING btree (owner_id, owner_type);
 
 
 --
 -- Name: index_user_beta_features_on_user_id_and_beta_feature_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_user_beta_features_on_user_id_and_beta_feature_id ON user_beta_features USING btree (user_id, beta_feature_id);
+CREATE INDEX index_user_beta_features_on_user_id_and_beta_feature_id ON public.user_beta_features USING btree (user_id, beta_feature_id);
 
 
 --
 -- Name: index_users_on_com_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_users_on_com_id ON users USING btree (com_id);
+CREATE UNIQUE INDEX index_users_on_com_id ON public.users USING btree (com_id);
 
 
 --
 -- Name: index_users_on_github_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_users_on_github_id ON users USING btree (github_id);
+CREATE UNIQUE INDEX index_users_on_github_id ON public.users USING btree (github_id);
 
 
 --
 -- Name: index_users_on_github_oauth_token; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_users_on_github_oauth_token ON users USING btree (github_oauth_token);
+CREATE UNIQUE INDEX index_users_on_github_oauth_token ON public.users USING btree (github_oauth_token);
 
 
 --
 -- Name: index_users_on_login; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_users_on_login ON users USING btree (login);
+CREATE INDEX index_users_on_login ON public.users USING btree (login);
 
 
 --
 -- Name: index_users_on_lower_login; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_users_on_lower_login ON users USING btree (lower((login)::text));
+CREATE INDEX index_users_on_lower_login ON public.users USING btree (lower((login)::text));
 
 
 --
 -- Name: index_users_on_org_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_users_on_org_id ON users USING btree (org_id);
+CREATE UNIQUE INDEX index_users_on_org_id ON public.users USING btree (org_id);
 
 
 --
 -- Name: index_users_on_updated_at; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_users_on_updated_at ON users USING btree (updated_at);
+CREATE INDEX index_users_on_updated_at ON public.users USING btree (updated_at);
 
 
 --
 -- Name: managed_repositories_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX managed_repositories_idx ON repositories USING btree (managed_by_installation_at);
+CREATE INDEX managed_repositories_idx ON public.repositories USING btree (managed_by_installation_at);
 
 
 --
 -- Name: owner_installations_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX owner_installations_idx ON installations USING btree (owner_id, owner_type) WHERE (removed_by_id IS NULL);
+CREATE UNIQUE INDEX owner_installations_idx ON public.installations USING btree (owner_id, owner_type) WHERE (removed_by_id IS NULL);
 
 
 --
 -- Name: owner_removed_installations_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX owner_removed_installations_idx ON installations USING btree (owner_id, owner_type, removed_by_id) WHERE (removed_by_id IS NOT NULL);
+CREATE UNIQUE INDEX owner_removed_installations_idx ON public.installations USING btree (owner_id, owner_type, removed_by_id) WHERE (removed_by_id IS NOT NULL);
 
 
 --
 -- Name: subscriptions_owner; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX subscriptions_owner ON subscriptions USING btree (owner_id, owner_type) WHERE ((status)::text = 'subscribed'::text);
+CREATE UNIQUE INDEX subscriptions_owner ON public.subscriptions USING btree (owner_id, owner_type) WHERE ((status)::text = 'subscribed'::text);
+
+
+--
+-- Name: unique_schema_migrations; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX unique_schema_migrations ON public.schema_migrations USING btree (version);
 
 
 --
 -- Name: builds set_updated_at_on_builds; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER set_updated_at_on_builds BEFORE INSERT OR UPDATE ON builds FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
+CREATE TRIGGER set_updated_at_on_builds BEFORE INSERT OR UPDATE ON public.builds FOR EACH ROW EXECUTE PROCEDURE public.set_updated_at();
 
 
 --
 -- Name: jobs set_updated_at_on_jobs; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER set_updated_at_on_jobs BEFORE INSERT OR UPDATE ON jobs FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
+CREATE TRIGGER set_updated_at_on_jobs BEFORE INSERT OR UPDATE ON public.jobs FOR EACH ROW EXECUTE PROCEDURE public.set_updated_at();
 
 
 --
 -- Name: branches trg_count_branch_deleted; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER trg_count_branch_deleted AFTER DELETE ON branches FOR EACH ROW WHEN ((now() > '2018-01-01 01:00:00+01'::timestamp with time zone)) EXECUTE PROCEDURE count_branches('-1');
+CREATE TRIGGER trg_count_branch_deleted AFTER DELETE ON public.branches FOR EACH ROW WHEN ((now() > '2018-01-01 01:00:00+01'::timestamp with time zone)) EXECUTE PROCEDURE public.count_branches('-1');
 
 
 --
 -- Name: branches trg_count_branch_inserted; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER trg_count_branch_inserted AFTER INSERT ON branches FOR EACH ROW WHEN ((now() > '2018-01-01 01:00:00+01'::timestamp with time zone)) EXECUTE PROCEDURE count_branches('1');
+CREATE TRIGGER trg_count_branch_inserted AFTER INSERT ON public.branches FOR EACH ROW WHEN ((now() > '2018-01-01 01:00:00+01'::timestamp with time zone)) EXECUTE PROCEDURE public.count_branches('1');
 
 
 --
 -- Name: builds trg_count_build_deleted; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER trg_count_build_deleted AFTER DELETE ON builds FOR EACH ROW WHEN ((now() > '2018-01-01 01:00:00+01'::timestamp with time zone)) EXECUTE PROCEDURE count_builds('-1');
+CREATE TRIGGER trg_count_build_deleted AFTER DELETE ON public.builds FOR EACH ROW WHEN ((now() > '2018-01-01 01:00:00+01'::timestamp with time zone)) EXECUTE PROCEDURE public.count_builds('-1');
 
 
 --
 -- Name: builds trg_count_build_inserted; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER trg_count_build_inserted AFTER INSERT ON builds FOR EACH ROW WHEN ((now() > '2018-01-01 01:00:00+01'::timestamp with time zone)) EXECUTE PROCEDURE count_builds('1');
+CREATE TRIGGER trg_count_build_inserted AFTER INSERT ON public.builds FOR EACH ROW WHEN ((now() > '2018-01-01 01:00:00+01'::timestamp with time zone)) EXECUTE PROCEDURE public.count_builds('1');
 
 
 --
 -- Name: commits trg_count_commit_deleted; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER trg_count_commit_deleted AFTER DELETE ON commits FOR EACH ROW WHEN ((now() > '2018-01-01 01:00:00+01'::timestamp with time zone)) EXECUTE PROCEDURE count_commits('-1');
+CREATE TRIGGER trg_count_commit_deleted AFTER DELETE ON public.commits FOR EACH ROW WHEN ((now() > '2018-01-01 01:00:00+01'::timestamp with time zone)) EXECUTE PROCEDURE public.count_commits('-1');
 
 
 --
 -- Name: commits trg_count_commit_inserted; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER trg_count_commit_inserted AFTER INSERT ON commits FOR EACH ROW WHEN ((now() > '2018-01-01 01:00:00+01'::timestamp with time zone)) EXECUTE PROCEDURE count_commits('1');
+CREATE TRIGGER trg_count_commit_inserted AFTER INSERT ON public.commits FOR EACH ROW WHEN ((now() > '2018-01-01 01:00:00+01'::timestamp with time zone)) EXECUTE PROCEDURE public.count_commits('1');
 
 
 --
 -- Name: jobs trg_count_job_deleted; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER trg_count_job_deleted AFTER DELETE ON jobs FOR EACH ROW WHEN ((now() > '2018-01-01 01:00:00+01'::timestamp with time zone)) EXECUTE PROCEDURE count_jobs('-1');
+CREATE TRIGGER trg_count_job_deleted AFTER DELETE ON public.jobs FOR EACH ROW WHEN ((now() > '2018-01-01 01:00:00+01'::timestamp with time zone)) EXECUTE PROCEDURE public.count_jobs('-1');
 
 
 --
 -- Name: jobs trg_count_job_inserted; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER trg_count_job_inserted AFTER INSERT ON jobs FOR EACH ROW WHEN ((now() > '2018-01-01 01:00:00+01'::timestamp with time zone)) EXECUTE PROCEDURE count_jobs('1');
+CREATE TRIGGER trg_count_job_inserted AFTER INSERT ON public.jobs FOR EACH ROW WHEN ((now() > '2018-01-01 01:00:00+01'::timestamp with time zone)) EXECUTE PROCEDURE public.count_jobs('1');
 
 
 --
 -- Name: pull_requests trg_count_pull_request_deleted; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER trg_count_pull_request_deleted AFTER DELETE ON pull_requests FOR EACH ROW WHEN ((now() > '2018-01-01 01:00:00+01'::timestamp with time zone)) EXECUTE PROCEDURE count_pull_requests('-1');
+CREATE TRIGGER trg_count_pull_request_deleted AFTER DELETE ON public.pull_requests FOR EACH ROW WHEN ((now() > '2018-01-01 01:00:00+01'::timestamp with time zone)) EXECUTE PROCEDURE public.count_pull_requests('-1');
 
 
 --
 -- Name: pull_requests trg_count_pull_request_inserted; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER trg_count_pull_request_inserted AFTER INSERT ON pull_requests FOR EACH ROW WHEN ((now() > '2018-01-01 01:00:00+01'::timestamp with time zone)) EXECUTE PROCEDURE count_pull_requests('1');
+CREATE TRIGGER trg_count_pull_request_inserted AFTER INSERT ON public.pull_requests FOR EACH ROW WHEN ((now() > '2018-01-01 01:00:00+01'::timestamp with time zone)) EXECUTE PROCEDURE public.count_pull_requests('1');
 
 
 --
 -- Name: requests trg_count_request_deleted; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER trg_count_request_deleted AFTER DELETE ON requests FOR EACH ROW WHEN ((now() > '2018-01-01 01:00:00+01'::timestamp with time zone)) EXECUTE PROCEDURE count_requests('-1');
+CREATE TRIGGER trg_count_request_deleted AFTER DELETE ON public.requests FOR EACH ROW WHEN ((now() > '2018-01-01 01:00:00+01'::timestamp with time zone)) EXECUTE PROCEDURE public.count_requests('-1');
 
 
 --
 -- Name: requests trg_count_request_inserted; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER trg_count_request_inserted AFTER INSERT ON requests FOR EACH ROW WHEN ((now() > '2018-01-01 01:00:00+01'::timestamp with time zone)) EXECUTE PROCEDURE count_requests('1');
+CREATE TRIGGER trg_count_request_inserted AFTER INSERT ON public.requests FOR EACH ROW WHEN ((now() > '2018-01-01 01:00:00+01'::timestamp with time zone)) EXECUTE PROCEDURE public.count_requests('1');
 
 
 --
 -- Name: tags trg_count_tag_deleted; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER trg_count_tag_deleted AFTER DELETE ON tags FOR EACH ROW WHEN ((now() > '2018-01-01 01:00:00+01'::timestamp with time zone)) EXECUTE PROCEDURE count_tags('-1');
+CREATE TRIGGER trg_count_tag_deleted AFTER DELETE ON public.tags FOR EACH ROW WHEN ((now() > '2018-01-01 01:00:00+01'::timestamp with time zone)) EXECUTE PROCEDURE public.count_tags('-1');
 
 
 --
 -- Name: tags trg_count_tag_inserted; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER trg_count_tag_inserted AFTER INSERT ON tags FOR EACH ROW WHEN ((now() > '2018-01-01 01:00:00+01'::timestamp with time zone)) EXECUTE PROCEDURE count_tags('1');
+CREATE TRIGGER trg_count_tag_inserted AFTER INSERT ON public.tags FOR EACH ROW WHEN ((now() > '2018-01-01 01:00:00+01'::timestamp with time zone)) EXECUTE PROCEDURE public.count_tags('1');
 
 
 --
 -- Name: installations fk_rails_2d567d406d; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY installations
-    ADD CONSTRAINT fk_rails_2d567d406d FOREIGN KEY (added_by_id) REFERENCES users(id);
+ALTER TABLE ONLY public.installations
+    ADD CONSTRAINT fk_rails_2d567d406d FOREIGN KEY (added_by_id) REFERENCES public.users(id);
 
 
 --
 -- Name: installations fk_rails_75a0a2a3b4; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY installations
-    ADD CONSTRAINT fk_rails_75a0a2a3b4 FOREIGN KEY (removed_by_id) REFERENCES users(id);
+ALTER TABLE ONLY public.installations
+    ADD CONSTRAINT fk_rails_75a0a2a3b4 FOREIGN KEY (removed_by_id) REFERENCES public.users(id);
 
 
 --
@@ -3730,6 +3716,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20130327100801'),
 ('20130418101437'),
 ('20130418103306'),
+('20130504230850'),
 ('20130505023259'),
 ('20130521115725'),
 ('20130521133050'),

--- a/db/main/structure.sql
+++ b/db/main/structure.sql
@@ -2680,14 +2680,6 @@ ALTER TABLE ONLY trials
 
 
 --
--- Name: installations unique_github_id_on_installations; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY installations
-    ADD CONSTRAINT unique_github_id_on_installations UNIQUE (github_id);
-
-
---
 -- Name: urls urls_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -2723,6 +2715,13 @@ CREATE UNIQUE INDEX favo_2col_uni_idx ON installations USING btree (owner_id, ow
 --
 
 CREATE UNIQUE INDEX favo_3col_uni_idx ON installations USING btree (owner_id, owner_type, removed_by_id) WHERE (removed_by_id IS NOT NULL);
+
+
+--
+-- Name: github_id_installations_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX github_id_installations_idx ON installations USING btree (github_id);
 
 
 --
@@ -3174,13 +3173,6 @@ CREATE INDEX index_repositories_on_lower_name ON repositories USING btree (lower
 
 
 --
--- Name: index_repositories_on_managed; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_repositories_on_managed ON repositories USING btree (managed_by_installation_at);
-
-
---
 -- Name: index_repositories_on_name; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -3479,6 +3471,13 @@ CREATE UNIQUE INDEX index_users_on_org_id ON users USING btree (org_id);
 --
 
 CREATE INDEX index_users_on_updated_at ON users USING btree (updated_at);
+
+
+--
+-- Name: managed_repositories_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX managed_repositories_idx ON repositories USING btree (managed_by_installation_at);
 
 
 --

--- a/db/main/structure.sql
+++ b/db/main/structure.sql
@@ -3,17 +3,9 @@ SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
-SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
 SET client_min_messages = warning;
 SET row_security = off;
-
---
--- Name: DATABASE postgres; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON DATABASE postgres IS 'default administrative connection database';
-
 
 --
 -- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
@@ -57,11 +49,13 @@ CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public;
 COMMENT ON EXTENSION pgcrypto IS 'cryptographic functions';
 
 
+SET search_path = public, pg_catalog;
+
 --
 -- Name: source_type; Type: TYPE; Schema: public; Owner: -
 --
 
-CREATE TYPE public.source_type AS ENUM (
+CREATE TYPE source_type AS ENUM (
     'manual',
     'stripe',
     'github',
@@ -73,7 +67,7 @@ CREATE TYPE public.source_type AS ENUM (
 -- Name: agg_all_repo_counts(); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION public.agg_all_repo_counts() RETURNS boolean
+CREATE FUNCTION agg_all_repo_counts() RETURNS boolean
     LANGUAGE plpgsql
     AS $$
 begin
@@ -135,7 +129,7 @@ $$;
 -- Name: agg_repo_counts(integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION public.agg_repo_counts(_repo_id integer) RETURNS boolean
+CREATE FUNCTION agg_repo_counts(_repo_id integer) RETURNS boolean
     LANGUAGE plpgsql
     AS $$
 begin
@@ -199,7 +193,7 @@ $$;
 -- Name: count_all_branches(integer, integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION public.count_all_branches(_count integer, _start integer, _end integer) RETURNS boolean
+CREATE FUNCTION count_all_branches(_count integer, _start integer, _end integer) RETURNS boolean
     LANGUAGE plpgsql
     AS $$
 declare max int;
@@ -224,7 +218,7 @@ $$;
 -- Name: count_all_builds(integer, integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION public.count_all_builds(_count integer, _start integer, _end integer) RETURNS boolean
+CREATE FUNCTION count_all_builds(_count integer, _start integer, _end integer) RETURNS boolean
     LANGUAGE plpgsql
     AS $$
 declare max int;
@@ -249,7 +243,7 @@ $$;
 -- Name: count_all_commits(integer, integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION public.count_all_commits(_count integer, _start integer, _end integer) RETURNS boolean
+CREATE FUNCTION count_all_commits(_count integer, _start integer, _end integer) RETURNS boolean
     LANGUAGE plpgsql
     AS $$
 declare max int;
@@ -274,7 +268,7 @@ $$;
 -- Name: count_all_jobs(integer, integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION public.count_all_jobs(_count integer, _start integer, _end integer) RETURNS boolean
+CREATE FUNCTION count_all_jobs(_count integer, _start integer, _end integer) RETURNS boolean
     LANGUAGE plpgsql
     AS $$
 declare max int;
@@ -299,7 +293,7 @@ $$;
 -- Name: count_all_pull_requests(integer, integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION public.count_all_pull_requests(_count integer, _start integer, _end integer) RETURNS boolean
+CREATE FUNCTION count_all_pull_requests(_count integer, _start integer, _end integer) RETURNS boolean
     LANGUAGE plpgsql
     AS $$
 declare max int;
@@ -324,7 +318,7 @@ $$;
 -- Name: count_all_requests(integer, integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION public.count_all_requests(_count integer, _start integer, _end integer) RETURNS boolean
+CREATE FUNCTION count_all_requests(_count integer, _start integer, _end integer) RETURNS boolean
     LANGUAGE plpgsql
     AS $$
 declare max int;
@@ -348,7 +342,7 @@ $$;
 -- Name: count_all_tags(integer, integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION public.count_all_tags(_count integer, _start integer, _end integer) RETURNS boolean
+CREATE FUNCTION count_all_tags(_count integer, _start integer, _end integer) RETURNS boolean
     LANGUAGE plpgsql
     AS $$
 declare max int;
@@ -373,7 +367,7 @@ $$;
 -- Name: count_branches(); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION public.count_branches() RETURNS trigger
+CREATE FUNCTION count_branches() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 declare
@@ -398,7 +392,7 @@ $$;
 -- Name: count_branches(integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION public.count_branches(_start integer, _end integer) RETURNS TABLE(repository_id integer, branches bigint, range character varying)
+CREATE FUNCTION count_branches(_start integer, _end integer) RETURNS TABLE(repository_id integer, branches bigint, range character varying)
     LANGUAGE plpgsql
     AS $$
 begin
@@ -415,7 +409,7 @@ $$;
 -- Name: count_builds(); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION public.count_builds() RETURNS trigger
+CREATE FUNCTION count_builds() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 declare
@@ -440,7 +434,7 @@ $$;
 -- Name: count_builds(integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION public.count_builds(_start integer, _end integer) RETURNS TABLE(repository_id integer, builds bigint, range character varying)
+CREATE FUNCTION count_builds(_start integer, _end integer) RETURNS TABLE(repository_id integer, builds bigint, range character varying)
     LANGUAGE plpgsql
     AS $$
 begin
@@ -456,7 +450,7 @@ $$;
 -- Name: count_commits(); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION public.count_commits() RETURNS trigger
+CREATE FUNCTION count_commits() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 declare
@@ -481,7 +475,7 @@ $$;
 -- Name: count_commits(integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION public.count_commits(_start integer, _end integer) RETURNS TABLE(repository_id integer, commits bigint, range character varying)
+CREATE FUNCTION count_commits(_start integer, _end integer) RETURNS TABLE(repository_id integer, commits bigint, range character varying)
     LANGUAGE plpgsql
     AS $$
 begin
@@ -498,7 +492,7 @@ $$;
 -- Name: count_jobs(); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION public.count_jobs() RETURNS trigger
+CREATE FUNCTION count_jobs() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 declare
@@ -523,7 +517,7 @@ $$;
 -- Name: count_jobs(integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION public.count_jobs(_start integer, _end integer) RETURNS TABLE(repository_id integer, jobs bigint, range character varying)
+CREATE FUNCTION count_jobs(_start integer, _end integer) RETURNS TABLE(repository_id integer, jobs bigint, range character varying)
     LANGUAGE plpgsql
     AS $$
 begin
@@ -539,7 +533,7 @@ $$;
 -- Name: count_pull_requests(); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION public.count_pull_requests() RETURNS trigger
+CREATE FUNCTION count_pull_requests() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 declare
@@ -564,7 +558,7 @@ $$;
 -- Name: count_pull_requests(integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION public.count_pull_requests(_start integer, _end integer) RETURNS TABLE(repository_id integer, pull_requests bigint, range character varying)
+CREATE FUNCTION count_pull_requests(_start integer, _end integer) RETURNS TABLE(repository_id integer, pull_requests bigint, range character varying)
     LANGUAGE plpgsql
     AS $$
 begin
@@ -581,7 +575,7 @@ $$;
 -- Name: count_requests(); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION public.count_requests() RETURNS trigger
+CREATE FUNCTION count_requests() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 declare
@@ -606,7 +600,7 @@ $$;
 -- Name: count_requests(integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION public.count_requests(_start integer, _end integer) RETURNS TABLE(repository_id integer, requests bigint, range character varying)
+CREATE FUNCTION count_requests(_start integer, _end integer) RETURNS TABLE(repository_id integer, requests bigint, range character varying)
     LANGUAGE plpgsql
     AS $$
 begin
@@ -622,7 +616,7 @@ $$;
 -- Name: count_tags(); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION public.count_tags() RETURNS trigger
+CREATE FUNCTION count_tags() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 declare
@@ -647,7 +641,7 @@ $$;
 -- Name: count_tags(integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION public.count_tags(_start integer, _end integer) RETURNS TABLE(repository_id integer, tags bigint, range character varying)
+CREATE FUNCTION count_tags(_start integer, _end integer) RETURNS TABLE(repository_id integer, tags bigint, range character varying)
     LANGUAGE plpgsql
     AS $$
 begin
@@ -664,7 +658,7 @@ $$;
 -- Name: set_updated_at(); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION public.set_updated_at() RETURNS trigger
+CREATE FUNCTION set_updated_at() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
       BEGIN
@@ -685,7 +679,7 @@ SET default_with_oids = false;
 -- Name: abuses; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.abuses (
+CREATE TABLE abuses (
     id integer NOT NULL,
     owner_type character varying,
     owner_id integer,
@@ -701,7 +695,7 @@ CREATE TABLE public.abuses (
 -- Name: abuses_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.abuses_id_seq
+CREATE SEQUENCE abuses_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -713,14 +707,14 @@ CREATE SEQUENCE public.abuses_id_seq
 -- Name: abuses_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.abuses_id_seq OWNED BY public.abuses.id;
+ALTER SEQUENCE abuses_id_seq OWNED BY abuses.id;
 
 
 --
 -- Name: ar_internal_metadata; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.ar_internal_metadata (
+CREATE TABLE ar_internal_metadata (
     key character varying NOT NULL,
     value character varying,
     created_at timestamp without time zone NOT NULL,
@@ -732,7 +726,7 @@ CREATE TABLE public.ar_internal_metadata (
 -- Name: beta_features; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.beta_features (
+CREATE TABLE beta_features (
     id integer NOT NULL,
     name character varying,
     description text,
@@ -748,7 +742,7 @@ CREATE TABLE public.beta_features (
 -- Name: beta_features_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.beta_features_id_seq
+CREATE SEQUENCE beta_features_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -760,14 +754,14 @@ CREATE SEQUENCE public.beta_features_id_seq
 -- Name: beta_features_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.beta_features_id_seq OWNED BY public.beta_features.id;
+ALTER SEQUENCE beta_features_id_seq OWNED BY beta_features.id;
 
 
 --
 -- Name: branches; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.branches (
+CREATE TABLE branches (
     id integer NOT NULL,
     repository_id integer NOT NULL,
     last_build_id integer,
@@ -784,7 +778,7 @@ CREATE TABLE public.branches (
 -- Name: branches_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.branches_id_seq
+CREATE SEQUENCE branches_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -796,14 +790,14 @@ CREATE SEQUENCE public.branches_id_seq
 -- Name: branches_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.branches_id_seq OWNED BY public.branches.id;
+ALTER SEQUENCE branches_id_seq OWNED BY branches.id;
 
 
 --
 -- Name: broadcasts; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.broadcasts (
+CREATE TABLE broadcasts (
     id integer NOT NULL,
     recipient_type character varying,
     recipient_id integer,
@@ -820,7 +814,7 @@ CREATE TABLE public.broadcasts (
 -- Name: broadcasts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.broadcasts_id_seq
+CREATE SEQUENCE broadcasts_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -832,14 +826,14 @@ CREATE SEQUENCE public.broadcasts_id_seq
 -- Name: broadcasts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.broadcasts_id_seq OWNED BY public.broadcasts.id;
+ALTER SEQUENCE broadcasts_id_seq OWNED BY broadcasts.id;
 
 
 --
 -- Name: build_configs; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.build_configs (
+CREATE TABLE build_configs (
     id integer NOT NULL,
     repository_id integer NOT NULL,
     key character varying NOT NULL,
@@ -851,7 +845,7 @@ CREATE TABLE public.build_configs (
 -- Name: build_configs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.build_configs_id_seq
+CREATE SEQUENCE build_configs_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -863,14 +857,14 @@ CREATE SEQUENCE public.build_configs_id_seq
 -- Name: build_configs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.build_configs_id_seq OWNED BY public.build_configs.id;
+ALTER SEQUENCE build_configs_id_seq OWNED BY build_configs.id;
 
 
 --
 -- Name: shared_builds_tasks_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.shared_builds_tasks_seq
+CREATE SEQUENCE shared_builds_tasks_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -882,8 +876,8 @@ CREATE SEQUENCE public.shared_builds_tasks_seq
 -- Name: builds; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.builds (
-    id bigint DEFAULT nextval('public.shared_builds_tasks_seq'::regclass) NOT NULL,
+CREATE TABLE builds (
+    id bigint DEFAULT nextval('shared_builds_tasks_seq'::regclass) NOT NULL,
     repository_id integer,
     number character varying,
     started_at timestamp without time zone,
@@ -932,7 +926,7 @@ CREATE TABLE public.builds (
 -- Name: builds_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.builds_id_seq
+CREATE SEQUENCE builds_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -944,14 +938,14 @@ CREATE SEQUENCE public.builds_id_seq
 -- Name: builds_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.builds_id_seq OWNED BY public.builds.id;
+ALTER SEQUENCE builds_id_seq OWNED BY builds.id;
 
 
 --
 -- Name: commits; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.commits (
+CREATE TABLE commits (
     id integer NOT NULL,
     repository_id integer,
     commit character varying,
@@ -977,7 +971,7 @@ CREATE TABLE public.commits (
 -- Name: commits_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.commits_id_seq
+CREATE SEQUENCE commits_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -989,14 +983,14 @@ CREATE SEQUENCE public.commits_id_seq
 -- Name: commits_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.commits_id_seq OWNED BY public.commits.id;
+ALTER SEQUENCE commits_id_seq OWNED BY commits.id;
 
 
 --
 -- Name: coupons; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.coupons (
+CREATE TABLE coupons (
     id integer NOT NULL,
     percent_off integer,
     coupon_id character varying,
@@ -1013,7 +1007,7 @@ CREATE TABLE public.coupons (
 -- Name: coupons_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.coupons_id_seq
+CREATE SEQUENCE coupons_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1025,14 +1019,14 @@ CREATE SEQUENCE public.coupons_id_seq
 -- Name: coupons_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.coupons_id_seq OWNED BY public.coupons.id;
+ALTER SEQUENCE coupons_id_seq OWNED BY coupons.id;
 
 
 --
 -- Name: crons; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.crons (
+CREATE TABLE crons (
     id integer NOT NULL,
     branch_id integer,
     "interval" character varying NOT NULL,
@@ -1050,7 +1044,7 @@ CREATE TABLE public.crons (
 -- Name: crons_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.crons_id_seq
+CREATE SEQUENCE crons_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1062,14 +1056,14 @@ CREATE SEQUENCE public.crons_id_seq
 -- Name: crons_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.crons_id_seq OWNED BY public.crons.id;
+ALTER SEQUENCE crons_id_seq OWNED BY crons.id;
 
 
 --
 -- Name: emails; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.emails (
+CREATE TABLE emails (
     id integer NOT NULL,
     user_id integer,
     email character varying,
@@ -1082,7 +1076,7 @@ CREATE TABLE public.emails (
 -- Name: emails_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.emails_id_seq
+CREATE SEQUENCE emails_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1094,14 +1088,14 @@ CREATE SEQUENCE public.emails_id_seq
 -- Name: emails_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.emails_id_seq OWNED BY public.emails.id;
+ALTER SEQUENCE emails_id_seq OWNED BY emails.id;
 
 
 --
 -- Name: installations; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.installations (
+CREATE TABLE installations (
     id integer NOT NULL,
     github_id integer,
     permissions jsonb,
@@ -1118,7 +1112,7 @@ CREATE TABLE public.installations (
 -- Name: installations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.installations_id_seq
+CREATE SEQUENCE installations_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1130,14 +1124,14 @@ CREATE SEQUENCE public.installations_id_seq
 -- Name: installations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.installations_id_seq OWNED BY public.installations.id;
+ALTER SEQUENCE installations_id_seq OWNED BY installations.id;
 
 
 --
 -- Name: invoices; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.invoices (
+CREATE TABLE invoices (
     id integer NOT NULL,
     object text,
     created_at timestamp without time zone,
@@ -1153,7 +1147,7 @@ CREATE TABLE public.invoices (
 -- Name: invoices_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.invoices_id_seq
+CREATE SEQUENCE invoices_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1165,14 +1159,14 @@ CREATE SEQUENCE public.invoices_id_seq
 -- Name: invoices_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.invoices_id_seq OWNED BY public.invoices.id;
+ALTER SEQUENCE invoices_id_seq OWNED BY invoices.id;
 
 
 --
 -- Name: job_configs; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.job_configs (
+CREATE TABLE job_configs (
     id integer NOT NULL,
     repository_id integer NOT NULL,
     key character varying NOT NULL,
@@ -1184,7 +1178,7 @@ CREATE TABLE public.job_configs (
 -- Name: job_configs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.job_configs_id_seq
+CREATE SEQUENCE job_configs_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1196,15 +1190,15 @@ CREATE SEQUENCE public.job_configs_id_seq
 -- Name: job_configs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.job_configs_id_seq OWNED BY public.job_configs.id;
+ALTER SEQUENCE job_configs_id_seq OWNED BY job_configs.id;
 
 
 --
 -- Name: jobs; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.jobs (
-    id bigint DEFAULT nextval('public.shared_builds_tasks_seq'::regclass) NOT NULL,
+CREATE TABLE jobs (
+    id bigint DEFAULT nextval('shared_builds_tasks_seq'::regclass) NOT NULL,
     repository_id integer,
     commit_id integer,
     source_type character varying,
@@ -1242,7 +1236,7 @@ CREATE TABLE public.jobs (
 -- Name: jobs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.jobs_id_seq
+CREATE SEQUENCE jobs_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1254,14 +1248,14 @@ CREATE SEQUENCE public.jobs_id_seq
 -- Name: jobs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.jobs_id_seq OWNED BY public.jobs.id;
+ALTER SEQUENCE jobs_id_seq OWNED BY jobs.id;
 
 
 --
 -- Name: memberships; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.memberships (
+CREATE TABLE memberships (
     id integer NOT NULL,
     organization_id integer,
     user_id integer,
@@ -1273,7 +1267,7 @@ CREATE TABLE public.memberships (
 -- Name: memberships_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.memberships_id_seq
+CREATE SEQUENCE memberships_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1285,14 +1279,14 @@ CREATE SEQUENCE public.memberships_id_seq
 -- Name: memberships_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.memberships_id_seq OWNED BY public.memberships.id;
+ALTER SEQUENCE memberships_id_seq OWNED BY memberships.id;
 
 
 --
 -- Name: messages; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.messages (
+CREATE TABLE messages (
     id integer NOT NULL,
     subject_id integer,
     subject_type character varying,
@@ -1309,7 +1303,7 @@ CREATE TABLE public.messages (
 -- Name: messages_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.messages_id_seq
+CREATE SEQUENCE messages_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1321,14 +1315,14 @@ CREATE SEQUENCE public.messages_id_seq
 -- Name: messages_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.messages_id_seq OWNED BY public.messages.id;
+ALTER SEQUENCE messages_id_seq OWNED BY messages.id;
 
 
 --
 -- Name: organizations; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.organizations (
+CREATE TABLE organizations (
     id integer NOT NULL,
     name character varying,
     login character varying,
@@ -1352,7 +1346,7 @@ CREATE TABLE public.organizations (
 -- Name: organizations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.organizations_id_seq
+CREATE SEQUENCE organizations_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1364,14 +1358,14 @@ CREATE SEQUENCE public.organizations_id_seq
 -- Name: organizations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.organizations_id_seq OWNED BY public.organizations.id;
+ALTER SEQUENCE organizations_id_seq OWNED BY organizations.id;
 
 
 --
 -- Name: owner_groups; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.owner_groups (
+CREATE TABLE owner_groups (
     id integer NOT NULL,
     uuid character varying,
     owner_type character varying,
@@ -1385,7 +1379,7 @@ CREATE TABLE public.owner_groups (
 -- Name: owner_groups_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.owner_groups_id_seq
+CREATE SEQUENCE owner_groups_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1397,14 +1391,14 @@ CREATE SEQUENCE public.owner_groups_id_seq
 -- Name: owner_groups_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.owner_groups_id_seq OWNED BY public.owner_groups.id;
+ALTER SEQUENCE owner_groups_id_seq OWNED BY owner_groups.id;
 
 
 --
 -- Name: permissions; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.permissions (
+CREATE TABLE permissions (
     id integer NOT NULL,
     user_id integer,
     repository_id integer,
@@ -1420,7 +1414,7 @@ CREATE TABLE public.permissions (
 -- Name: permissions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.permissions_id_seq
+CREATE SEQUENCE permissions_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1432,14 +1426,14 @@ CREATE SEQUENCE public.permissions_id_seq
 -- Name: permissions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.permissions_id_seq OWNED BY public.permissions.id;
+ALTER SEQUENCE permissions_id_seq OWNED BY permissions.id;
 
 
 --
 -- Name: pull_requests; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.pull_requests (
+CREATE TABLE pull_requests (
     id integer NOT NULL,
     repository_id integer,
     number integer,
@@ -1459,7 +1453,7 @@ CREATE TABLE public.pull_requests (
 -- Name: pull_requests_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.pull_requests_id_seq
+CREATE SEQUENCE pull_requests_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1471,14 +1465,14 @@ CREATE SEQUENCE public.pull_requests_id_seq
 -- Name: pull_requests_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.pull_requests_id_seq OWNED BY public.pull_requests.id;
+ALTER SEQUENCE pull_requests_id_seq OWNED BY pull_requests.id;
 
 
 --
 -- Name: queueable_jobs; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.queueable_jobs (
+CREATE TABLE queueable_jobs (
     id integer NOT NULL,
     job_id integer
 );
@@ -1488,7 +1482,7 @@ CREATE TABLE public.queueable_jobs (
 -- Name: queueable_jobs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.queueable_jobs_id_seq
+CREATE SEQUENCE queueable_jobs_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1500,14 +1494,14 @@ CREATE SEQUENCE public.queueable_jobs_id_seq
 -- Name: queueable_jobs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.queueable_jobs_id_seq OWNED BY public.queueable_jobs.id;
+ALTER SEQUENCE queueable_jobs_id_seq OWNED BY queueable_jobs.id;
 
 
 --
 -- Name: repo_counts; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.repo_counts (
+CREATE TABLE repo_counts (
     repository_id integer NOT NULL,
     requests integer,
     commits integer,
@@ -1525,7 +1519,7 @@ CREATE TABLE public.repo_counts (
 -- Name: repositories; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.repositories (
+CREATE TABLE repositories (
     id integer NOT NULL,
     name character varying,
     url character varying,
@@ -1564,7 +1558,7 @@ CREATE TABLE public.repositories (
 -- Name: repositories_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.repositories_id_seq
+CREATE SEQUENCE repositories_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1576,14 +1570,14 @@ CREATE SEQUENCE public.repositories_id_seq
 -- Name: repositories_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.repositories_id_seq OWNED BY public.repositories.id;
+ALTER SEQUENCE repositories_id_seq OWNED BY repositories.id;
 
 
 --
 -- Name: request_configs; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.request_configs (
+CREATE TABLE request_configs (
     id integer NOT NULL,
     repository_id integer NOT NULL,
     key character varying NOT NULL,
@@ -1595,7 +1589,7 @@ CREATE TABLE public.request_configs (
 -- Name: request_configs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.request_configs_id_seq
+CREATE SEQUENCE request_configs_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1607,14 +1601,14 @@ CREATE SEQUENCE public.request_configs_id_seq
 -- Name: request_configs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.request_configs_id_seq OWNED BY public.request_configs.id;
+ALTER SEQUENCE request_configs_id_seq OWNED BY request_configs.id;
 
 
 --
 -- Name: request_payloads; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.request_payloads (
+CREATE TABLE request_payloads (
     id integer NOT NULL,
     request_id integer NOT NULL,
     payload text,
@@ -1627,7 +1621,7 @@ CREATE TABLE public.request_payloads (
 -- Name: request_payloads_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.request_payloads_id_seq
+CREATE SEQUENCE request_payloads_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1639,14 +1633,14 @@ CREATE SEQUENCE public.request_payloads_id_seq
 -- Name: request_payloads_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.request_payloads_id_seq OWNED BY public.request_payloads.id;
+ALTER SEQUENCE request_payloads_id_seq OWNED BY request_payloads.id;
 
 
 --
 -- Name: requests; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.requests (
+CREATE TABLE requests (
     id integer NOT NULL,
     repository_id integer,
     commit_id integer,
@@ -1682,7 +1676,7 @@ CREATE TABLE public.requests (
 -- Name: requests_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.requests_id_seq
+CREATE SEQUENCE requests_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1694,14 +1688,14 @@ CREATE SEQUENCE public.requests_id_seq
 -- Name: requests_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.requests_id_seq OWNED BY public.requests.id;
+ALTER SEQUENCE requests_id_seq OWNED BY requests.id;
 
 
 --
 -- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.schema_migrations (
+CREATE TABLE schema_migrations (
     version character varying NOT NULL
 );
 
@@ -1710,7 +1704,7 @@ CREATE TABLE public.schema_migrations (
 -- Name: ssl_keys; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.ssl_keys (
+CREATE TABLE ssl_keys (
     id integer NOT NULL,
     repository_id integer,
     public_key text,
@@ -1726,7 +1720,7 @@ CREATE TABLE public.ssl_keys (
 -- Name: ssl_keys_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.ssl_keys_id_seq
+CREATE SEQUENCE ssl_keys_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1738,14 +1732,14 @@ CREATE SEQUENCE public.ssl_keys_id_seq
 -- Name: ssl_keys_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.ssl_keys_id_seq OWNED BY public.ssl_keys.id;
+ALTER SEQUENCE ssl_keys_id_seq OWNED BY ssl_keys.id;
 
 
 --
 -- Name: stages; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.stages (
+CREATE TABLE stages (
     id integer NOT NULL,
     build_id integer,
     number integer,
@@ -1762,7 +1756,7 @@ CREATE TABLE public.stages (
 -- Name: stages_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.stages_id_seq
+CREATE SEQUENCE stages_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1774,14 +1768,14 @@ CREATE SEQUENCE public.stages_id_seq
 -- Name: stages_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.stages_id_seq OWNED BY public.stages.id;
+ALTER SEQUENCE stages_id_seq OWNED BY stages.id;
 
 
 --
 -- Name: stars; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.stars (
+CREATE TABLE stars (
     id integer NOT NULL,
     repository_id integer,
     user_id integer,
@@ -1794,7 +1788,7 @@ CREATE TABLE public.stars (
 -- Name: stars_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.stars_id_seq
+CREATE SEQUENCE stars_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1806,14 +1800,14 @@ CREATE SEQUENCE public.stars_id_seq
 -- Name: stars_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.stars_id_seq OWNED BY public.stars.id;
+ALTER SEQUENCE stars_id_seq OWNED BY stars.id;
 
 
 --
 -- Name: stripe_events; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.stripe_events (
+CREATE TABLE stripe_events (
     id integer NOT NULL,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
@@ -1828,7 +1822,7 @@ CREATE TABLE public.stripe_events (
 -- Name: stripe_events_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.stripe_events_id_seq
+CREATE SEQUENCE stripe_events_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1840,14 +1834,14 @@ CREATE SEQUENCE public.stripe_events_id_seq
 -- Name: stripe_events_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.stripe_events_id_seq OWNED BY public.stripe_events.id;
+ALTER SEQUENCE stripe_events_id_seq OWNED BY stripe_events.id;
 
 
 --
 -- Name: subscriptions; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.subscriptions (
+CREATE TABLE subscriptions (
     id integer NOT NULL,
     cc_token character varying,
     valid_to timestamp without time zone,
@@ -1876,7 +1870,7 @@ CREATE TABLE public.subscriptions (
     canceled_at timestamp without time zone,
     canceled_by_id integer,
     status character varying,
-    source public.source_type DEFAULT 'unknown'::public.source_type NOT NULL,
+    source source_type DEFAULT 'unknown'::source_type NOT NULL,
     concurrency integer
 );
 
@@ -1885,7 +1879,7 @@ CREATE TABLE public.subscriptions (
 -- Name: subscriptions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.subscriptions_id_seq
+CREATE SEQUENCE subscriptions_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1897,14 +1891,14 @@ CREATE SEQUENCE public.subscriptions_id_seq
 -- Name: subscriptions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.subscriptions_id_seq OWNED BY public.subscriptions.id;
+ALTER SEQUENCE subscriptions_id_seq OWNED BY subscriptions.id;
 
 
 --
 -- Name: tags; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.tags (
+CREATE TABLE tags (
     id integer NOT NULL,
     repository_id integer,
     name character varying,
@@ -1921,7 +1915,7 @@ CREATE TABLE public.tags (
 -- Name: tags_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.tags_id_seq
+CREATE SEQUENCE tags_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1933,14 +1927,14 @@ CREATE SEQUENCE public.tags_id_seq
 -- Name: tags_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.tags_id_seq OWNED BY public.tags.id;
+ALTER SEQUENCE tags_id_seq OWNED BY tags.id;
 
 
 --
 -- Name: tokens; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.tokens (
+CREATE TABLE tokens (
     id integer NOT NULL,
     user_id integer,
     token character varying,
@@ -1953,7 +1947,7 @@ CREATE TABLE public.tokens (
 -- Name: tokens_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.tokens_id_seq
+CREATE SEQUENCE tokens_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1965,14 +1959,14 @@ CREATE SEQUENCE public.tokens_id_seq
 -- Name: tokens_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.tokens_id_seq OWNED BY public.tokens.id;
+ALTER SEQUENCE tokens_id_seq OWNED BY tokens.id;
 
 
 --
 -- Name: trial_allowances; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.trial_allowances (
+CREATE TABLE trial_allowances (
     id integer NOT NULL,
     trial_id integer,
     creator_id integer,
@@ -1988,7 +1982,7 @@ CREATE TABLE public.trial_allowances (
 -- Name: trial_allowances_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.trial_allowances_id_seq
+CREATE SEQUENCE trial_allowances_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2000,14 +1994,14 @@ CREATE SEQUENCE public.trial_allowances_id_seq
 -- Name: trial_allowances_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.trial_allowances_id_seq OWNED BY public.trial_allowances.id;
+ALTER SEQUENCE trial_allowances_id_seq OWNED BY trial_allowances.id;
 
 
 --
 -- Name: trials; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.trials (
+CREATE TABLE trials (
     id integer NOT NULL,
     owner_type character varying,
     owner_id integer,
@@ -2022,7 +2016,7 @@ CREATE TABLE public.trials (
 -- Name: trials_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.trials_id_seq
+CREATE SEQUENCE trials_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2034,14 +2028,14 @@ CREATE SEQUENCE public.trials_id_seq
 -- Name: trials_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.trials_id_seq OWNED BY public.trials.id;
+ALTER SEQUENCE trials_id_seq OWNED BY trials.id;
 
 
 --
 -- Name: urls; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.urls (
+CREATE TABLE urls (
     id integer NOT NULL,
     url character varying,
     code character varying,
@@ -2054,7 +2048,7 @@ CREATE TABLE public.urls (
 -- Name: urls_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.urls_id_seq
+CREATE SEQUENCE urls_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2066,14 +2060,14 @@ CREATE SEQUENCE public.urls_id_seq
 -- Name: urls_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.urls_id_seq OWNED BY public.urls.id;
+ALTER SEQUENCE urls_id_seq OWNED BY urls.id;
 
 
 --
 -- Name: user_beta_features; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.user_beta_features (
+CREATE TABLE user_beta_features (
     id integer NOT NULL,
     user_id integer,
     beta_feature_id integer,
@@ -2087,7 +2081,7 @@ CREATE TABLE public.user_beta_features (
 -- Name: user_beta_features_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.user_beta_features_id_seq
+CREATE SEQUENCE user_beta_features_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2099,14 +2093,14 @@ CREATE SEQUENCE public.user_beta_features_id_seq
 -- Name: user_beta_features_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.user_beta_features_id_seq OWNED BY public.user_beta_features.id;
+ALTER SEQUENCE user_beta_features_id_seq OWNED BY user_beta_features.id;
 
 
 --
 -- Name: users; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.users (
+CREATE TABLE users (
     id integer NOT NULL,
     name character varying,
     login character varying,
@@ -2137,7 +2131,7 @@ CREATE TABLE public.users (
 -- Name: users_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.users_id_seq
+CREATE SEQUENCE users_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2149,259 +2143,259 @@ CREATE SEQUENCE public.users_id_seq
 -- Name: users_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.users_id_seq OWNED BY public.users.id;
+ALTER SEQUENCE users_id_seq OWNED BY users.id;
 
 
 --
 -- Name: abuses id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.abuses ALTER COLUMN id SET DEFAULT nextval('public.abuses_id_seq'::regclass);
+ALTER TABLE ONLY abuses ALTER COLUMN id SET DEFAULT nextval('abuses_id_seq'::regclass);
 
 
 --
 -- Name: beta_features id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.beta_features ALTER COLUMN id SET DEFAULT nextval('public.beta_features_id_seq'::regclass);
+ALTER TABLE ONLY beta_features ALTER COLUMN id SET DEFAULT nextval('beta_features_id_seq'::regclass);
 
 
 --
 -- Name: branches id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.branches ALTER COLUMN id SET DEFAULT nextval('public.branches_id_seq'::regclass);
+ALTER TABLE ONLY branches ALTER COLUMN id SET DEFAULT nextval('branches_id_seq'::regclass);
 
 
 --
 -- Name: broadcasts id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.broadcasts ALTER COLUMN id SET DEFAULT nextval('public.broadcasts_id_seq'::regclass);
+ALTER TABLE ONLY broadcasts ALTER COLUMN id SET DEFAULT nextval('broadcasts_id_seq'::regclass);
 
 
 --
 -- Name: build_configs id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.build_configs ALTER COLUMN id SET DEFAULT nextval('public.build_configs_id_seq'::regclass);
+ALTER TABLE ONLY build_configs ALTER COLUMN id SET DEFAULT nextval('build_configs_id_seq'::regclass);
 
 
 --
 -- Name: commits id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.commits ALTER COLUMN id SET DEFAULT nextval('public.commits_id_seq'::regclass);
+ALTER TABLE ONLY commits ALTER COLUMN id SET DEFAULT nextval('commits_id_seq'::regclass);
 
 
 --
 -- Name: coupons id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.coupons ALTER COLUMN id SET DEFAULT nextval('public.coupons_id_seq'::regclass);
+ALTER TABLE ONLY coupons ALTER COLUMN id SET DEFAULT nextval('coupons_id_seq'::regclass);
 
 
 --
 -- Name: crons id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.crons ALTER COLUMN id SET DEFAULT nextval('public.crons_id_seq'::regclass);
+ALTER TABLE ONLY crons ALTER COLUMN id SET DEFAULT nextval('crons_id_seq'::regclass);
 
 
 --
 -- Name: emails id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.emails ALTER COLUMN id SET DEFAULT nextval('public.emails_id_seq'::regclass);
+ALTER TABLE ONLY emails ALTER COLUMN id SET DEFAULT nextval('emails_id_seq'::regclass);
 
 
 --
 -- Name: installations id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.installations ALTER COLUMN id SET DEFAULT nextval('public.installations_id_seq'::regclass);
+ALTER TABLE ONLY installations ALTER COLUMN id SET DEFAULT nextval('installations_id_seq'::regclass);
 
 
 --
 -- Name: invoices id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.invoices ALTER COLUMN id SET DEFAULT nextval('public.invoices_id_seq'::regclass);
+ALTER TABLE ONLY invoices ALTER COLUMN id SET DEFAULT nextval('invoices_id_seq'::regclass);
 
 
 --
 -- Name: job_configs id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.job_configs ALTER COLUMN id SET DEFAULT nextval('public.job_configs_id_seq'::regclass);
+ALTER TABLE ONLY job_configs ALTER COLUMN id SET DEFAULT nextval('job_configs_id_seq'::regclass);
 
 
 --
 -- Name: memberships id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.memberships ALTER COLUMN id SET DEFAULT nextval('public.memberships_id_seq'::regclass);
+ALTER TABLE ONLY memberships ALTER COLUMN id SET DEFAULT nextval('memberships_id_seq'::regclass);
 
 
 --
 -- Name: messages id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.messages ALTER COLUMN id SET DEFAULT nextval('public.messages_id_seq'::regclass);
+ALTER TABLE ONLY messages ALTER COLUMN id SET DEFAULT nextval('messages_id_seq'::regclass);
 
 
 --
 -- Name: organizations id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.organizations ALTER COLUMN id SET DEFAULT nextval('public.organizations_id_seq'::regclass);
+ALTER TABLE ONLY organizations ALTER COLUMN id SET DEFAULT nextval('organizations_id_seq'::regclass);
 
 
 --
 -- Name: owner_groups id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.owner_groups ALTER COLUMN id SET DEFAULT nextval('public.owner_groups_id_seq'::regclass);
+ALTER TABLE ONLY owner_groups ALTER COLUMN id SET DEFAULT nextval('owner_groups_id_seq'::regclass);
 
 
 --
 -- Name: permissions id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.permissions ALTER COLUMN id SET DEFAULT nextval('public.permissions_id_seq'::regclass);
+ALTER TABLE ONLY permissions ALTER COLUMN id SET DEFAULT nextval('permissions_id_seq'::regclass);
 
 
 --
 -- Name: pull_requests id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.pull_requests ALTER COLUMN id SET DEFAULT nextval('public.pull_requests_id_seq'::regclass);
+ALTER TABLE ONLY pull_requests ALTER COLUMN id SET DEFAULT nextval('pull_requests_id_seq'::regclass);
 
 
 --
 -- Name: queueable_jobs id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.queueable_jobs ALTER COLUMN id SET DEFAULT nextval('public.queueable_jobs_id_seq'::regclass);
+ALTER TABLE ONLY queueable_jobs ALTER COLUMN id SET DEFAULT nextval('queueable_jobs_id_seq'::regclass);
 
 
 --
 -- Name: repositories id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.repositories ALTER COLUMN id SET DEFAULT nextval('public.repositories_id_seq'::regclass);
+ALTER TABLE ONLY repositories ALTER COLUMN id SET DEFAULT nextval('repositories_id_seq'::regclass);
 
 
 --
 -- Name: request_configs id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.request_configs ALTER COLUMN id SET DEFAULT nextval('public.request_configs_id_seq'::regclass);
+ALTER TABLE ONLY request_configs ALTER COLUMN id SET DEFAULT nextval('request_configs_id_seq'::regclass);
 
 
 --
 -- Name: request_payloads id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.request_payloads ALTER COLUMN id SET DEFAULT nextval('public.request_payloads_id_seq'::regclass);
+ALTER TABLE ONLY request_payloads ALTER COLUMN id SET DEFAULT nextval('request_payloads_id_seq'::regclass);
 
 
 --
 -- Name: requests id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.requests ALTER COLUMN id SET DEFAULT nextval('public.requests_id_seq'::regclass);
+ALTER TABLE ONLY requests ALTER COLUMN id SET DEFAULT nextval('requests_id_seq'::regclass);
 
 
 --
 -- Name: ssl_keys id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.ssl_keys ALTER COLUMN id SET DEFAULT nextval('public.ssl_keys_id_seq'::regclass);
+ALTER TABLE ONLY ssl_keys ALTER COLUMN id SET DEFAULT nextval('ssl_keys_id_seq'::regclass);
 
 
 --
 -- Name: stages id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.stages ALTER COLUMN id SET DEFAULT nextval('public.stages_id_seq'::regclass);
+ALTER TABLE ONLY stages ALTER COLUMN id SET DEFAULT nextval('stages_id_seq'::regclass);
 
 
 --
 -- Name: stars id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.stars ALTER COLUMN id SET DEFAULT nextval('public.stars_id_seq'::regclass);
+ALTER TABLE ONLY stars ALTER COLUMN id SET DEFAULT nextval('stars_id_seq'::regclass);
 
 
 --
 -- Name: stripe_events id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.stripe_events ALTER COLUMN id SET DEFAULT nextval('public.stripe_events_id_seq'::regclass);
+ALTER TABLE ONLY stripe_events ALTER COLUMN id SET DEFAULT nextval('stripe_events_id_seq'::regclass);
 
 
 --
 -- Name: subscriptions id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.subscriptions ALTER COLUMN id SET DEFAULT nextval('public.subscriptions_id_seq'::regclass);
+ALTER TABLE ONLY subscriptions ALTER COLUMN id SET DEFAULT nextval('subscriptions_id_seq'::regclass);
 
 
 --
 -- Name: tags id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.tags ALTER COLUMN id SET DEFAULT nextval('public.tags_id_seq'::regclass);
+ALTER TABLE ONLY tags ALTER COLUMN id SET DEFAULT nextval('tags_id_seq'::regclass);
 
 
 --
 -- Name: tokens id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.tokens ALTER COLUMN id SET DEFAULT nextval('public.tokens_id_seq'::regclass);
+ALTER TABLE ONLY tokens ALTER COLUMN id SET DEFAULT nextval('tokens_id_seq'::regclass);
 
 
 --
 -- Name: trial_allowances id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.trial_allowances ALTER COLUMN id SET DEFAULT nextval('public.trial_allowances_id_seq'::regclass);
+ALTER TABLE ONLY trial_allowances ALTER COLUMN id SET DEFAULT nextval('trial_allowances_id_seq'::regclass);
 
 
 --
 -- Name: trials id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.trials ALTER COLUMN id SET DEFAULT nextval('public.trials_id_seq'::regclass);
+ALTER TABLE ONLY trials ALTER COLUMN id SET DEFAULT nextval('trials_id_seq'::regclass);
 
 
 --
 -- Name: urls id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.urls ALTER COLUMN id SET DEFAULT nextval('public.urls_id_seq'::regclass);
+ALTER TABLE ONLY urls ALTER COLUMN id SET DEFAULT nextval('urls_id_seq'::regclass);
 
 
 --
 -- Name: user_beta_features id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.user_beta_features ALTER COLUMN id SET DEFAULT nextval('public.user_beta_features_id_seq'::regclass);
+ALTER TABLE ONLY user_beta_features ALTER COLUMN id SET DEFAULT nextval('user_beta_features_id_seq'::regclass);
 
 
 --
 -- Name: users id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.users ALTER COLUMN id SET DEFAULT nextval('public.users_id_seq'::regclass);
+ALTER TABLE ONLY users ALTER COLUMN id SET DEFAULT nextval('users_id_seq'::regclass);
 
 
 --
 -- Name: abuses abuses_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.abuses
+ALTER TABLE ONLY abuses
     ADD CONSTRAINT abuses_pkey PRIMARY KEY (id);
 
 
@@ -2409,7 +2403,7 @@ ALTER TABLE ONLY public.abuses
 -- Name: ar_internal_metadata ar_internal_metadata_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.ar_internal_metadata
+ALTER TABLE ONLY ar_internal_metadata
     ADD CONSTRAINT ar_internal_metadata_pkey PRIMARY KEY (key);
 
 
@@ -2417,7 +2411,7 @@ ALTER TABLE ONLY public.ar_internal_metadata
 -- Name: beta_features beta_features_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.beta_features
+ALTER TABLE ONLY beta_features
     ADD CONSTRAINT beta_features_pkey PRIMARY KEY (id);
 
 
@@ -2425,7 +2419,7 @@ ALTER TABLE ONLY public.beta_features
 -- Name: branches branches_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.branches
+ALTER TABLE ONLY branches
     ADD CONSTRAINT branches_pkey PRIMARY KEY (id);
 
 
@@ -2433,7 +2427,7 @@ ALTER TABLE ONLY public.branches
 -- Name: broadcasts broadcasts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.broadcasts
+ALTER TABLE ONLY broadcasts
     ADD CONSTRAINT broadcasts_pkey PRIMARY KEY (id);
 
 
@@ -2441,7 +2435,7 @@ ALTER TABLE ONLY public.broadcasts
 -- Name: build_configs build_configs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.build_configs
+ALTER TABLE ONLY build_configs
     ADD CONSTRAINT build_configs_pkey PRIMARY KEY (id);
 
 
@@ -2449,7 +2443,7 @@ ALTER TABLE ONLY public.build_configs
 -- Name: builds builds_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.builds
+ALTER TABLE ONLY builds
     ADD CONSTRAINT builds_pkey PRIMARY KEY (id);
 
 
@@ -2457,7 +2451,7 @@ ALTER TABLE ONLY public.builds
 -- Name: commits commits_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.commits
+ALTER TABLE ONLY commits
     ADD CONSTRAINT commits_pkey PRIMARY KEY (id);
 
 
@@ -2465,7 +2459,7 @@ ALTER TABLE ONLY public.commits
 -- Name: coupons coupons_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.coupons
+ALTER TABLE ONLY coupons
     ADD CONSTRAINT coupons_pkey PRIMARY KEY (id);
 
 
@@ -2473,7 +2467,7 @@ ALTER TABLE ONLY public.coupons
 -- Name: crons crons_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.crons
+ALTER TABLE ONLY crons
     ADD CONSTRAINT crons_pkey PRIMARY KEY (id);
 
 
@@ -2481,7 +2475,7 @@ ALTER TABLE ONLY public.crons
 -- Name: emails emails_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.emails
+ALTER TABLE ONLY emails
     ADD CONSTRAINT emails_pkey PRIMARY KEY (id);
 
 
@@ -2489,7 +2483,7 @@ ALTER TABLE ONLY public.emails
 -- Name: installations installations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.installations
+ALTER TABLE ONLY installations
     ADD CONSTRAINT installations_pkey PRIMARY KEY (id);
 
 
@@ -2497,7 +2491,7 @@ ALTER TABLE ONLY public.installations
 -- Name: invoices invoices_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.invoices
+ALTER TABLE ONLY invoices
     ADD CONSTRAINT invoices_pkey PRIMARY KEY (id);
 
 
@@ -2505,7 +2499,7 @@ ALTER TABLE ONLY public.invoices
 -- Name: job_configs job_configs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.job_configs
+ALTER TABLE ONLY job_configs
     ADD CONSTRAINT job_configs_pkey PRIMARY KEY (id);
 
 
@@ -2513,7 +2507,7 @@ ALTER TABLE ONLY public.job_configs
 -- Name: jobs jobs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.jobs
+ALTER TABLE ONLY jobs
     ADD CONSTRAINT jobs_pkey PRIMARY KEY (id);
 
 
@@ -2521,7 +2515,7 @@ ALTER TABLE ONLY public.jobs
 -- Name: memberships memberships_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.memberships
+ALTER TABLE ONLY memberships
     ADD CONSTRAINT memberships_pkey PRIMARY KEY (id);
 
 
@@ -2529,7 +2523,7 @@ ALTER TABLE ONLY public.memberships
 -- Name: messages messages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.messages
+ALTER TABLE ONLY messages
     ADD CONSTRAINT messages_pkey PRIMARY KEY (id);
 
 
@@ -2537,7 +2531,7 @@ ALTER TABLE ONLY public.messages
 -- Name: organizations organizations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.organizations
+ALTER TABLE ONLY organizations
     ADD CONSTRAINT organizations_pkey PRIMARY KEY (id);
 
 
@@ -2545,7 +2539,7 @@ ALTER TABLE ONLY public.organizations
 -- Name: owner_groups owner_groups_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.owner_groups
+ALTER TABLE ONLY owner_groups
     ADD CONSTRAINT owner_groups_pkey PRIMARY KEY (id);
 
 
@@ -2553,7 +2547,7 @@ ALTER TABLE ONLY public.owner_groups
 -- Name: permissions permissions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.permissions
+ALTER TABLE ONLY permissions
     ADD CONSTRAINT permissions_pkey PRIMARY KEY (id);
 
 
@@ -2561,7 +2555,7 @@ ALTER TABLE ONLY public.permissions
 -- Name: pull_requests pull_requests_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.pull_requests
+ALTER TABLE ONLY pull_requests
     ADD CONSTRAINT pull_requests_pkey PRIMARY KEY (id);
 
 
@@ -2569,7 +2563,7 @@ ALTER TABLE ONLY public.pull_requests
 -- Name: queueable_jobs queueable_jobs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.queueable_jobs
+ALTER TABLE ONLY queueable_jobs
     ADD CONSTRAINT queueable_jobs_pkey PRIMARY KEY (id);
 
 
@@ -2577,7 +2571,7 @@ ALTER TABLE ONLY public.queueable_jobs
 -- Name: repositories repositories_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.repositories
+ALTER TABLE ONLY repositories
     ADD CONSTRAINT repositories_pkey PRIMARY KEY (id);
 
 
@@ -2585,7 +2579,7 @@ ALTER TABLE ONLY public.repositories
 -- Name: request_configs request_configs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.request_configs
+ALTER TABLE ONLY request_configs
     ADD CONSTRAINT request_configs_pkey PRIMARY KEY (id);
 
 
@@ -2593,7 +2587,7 @@ ALTER TABLE ONLY public.request_configs
 -- Name: request_payloads request_payloads_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.request_payloads
+ALTER TABLE ONLY request_payloads
     ADD CONSTRAINT request_payloads_pkey PRIMARY KEY (id);
 
 
@@ -2601,7 +2595,7 @@ ALTER TABLE ONLY public.request_payloads
 -- Name: requests requests_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.requests
+ALTER TABLE ONLY requests
     ADD CONSTRAINT requests_pkey PRIMARY KEY (id);
 
 
@@ -2609,7 +2603,7 @@ ALTER TABLE ONLY public.requests
 -- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.schema_migrations
+ALTER TABLE ONLY schema_migrations
     ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
 
 
@@ -2617,7 +2611,7 @@ ALTER TABLE ONLY public.schema_migrations
 -- Name: ssl_keys ssl_keys_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.ssl_keys
+ALTER TABLE ONLY ssl_keys
     ADD CONSTRAINT ssl_keys_pkey PRIMARY KEY (id);
 
 
@@ -2625,7 +2619,7 @@ ALTER TABLE ONLY public.ssl_keys
 -- Name: stages stages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.stages
+ALTER TABLE ONLY stages
     ADD CONSTRAINT stages_pkey PRIMARY KEY (id);
 
 
@@ -2633,7 +2627,7 @@ ALTER TABLE ONLY public.stages
 -- Name: stars stars_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.stars
+ALTER TABLE ONLY stars
     ADD CONSTRAINT stars_pkey PRIMARY KEY (id);
 
 
@@ -2641,7 +2635,7 @@ ALTER TABLE ONLY public.stars
 -- Name: stripe_events stripe_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.stripe_events
+ALTER TABLE ONLY stripe_events
     ADD CONSTRAINT stripe_events_pkey PRIMARY KEY (id);
 
 
@@ -2649,7 +2643,7 @@ ALTER TABLE ONLY public.stripe_events
 -- Name: subscriptions subscriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.subscriptions
+ALTER TABLE ONLY subscriptions
     ADD CONSTRAINT subscriptions_pkey PRIMARY KEY (id);
 
 
@@ -2657,7 +2651,7 @@ ALTER TABLE ONLY public.subscriptions
 -- Name: tags tags_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.tags
+ALTER TABLE ONLY tags
     ADD CONSTRAINT tags_pkey PRIMARY KEY (id);
 
 
@@ -2665,7 +2659,7 @@ ALTER TABLE ONLY public.tags
 -- Name: tokens tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.tokens
+ALTER TABLE ONLY tokens
     ADD CONSTRAINT tokens_pkey PRIMARY KEY (id);
 
 
@@ -2673,7 +2667,7 @@ ALTER TABLE ONLY public.tokens
 -- Name: trial_allowances trial_allowances_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.trial_allowances
+ALTER TABLE ONLY trial_allowances
     ADD CONSTRAINT trial_allowances_pkey PRIMARY KEY (id);
 
 
@@ -2681,15 +2675,23 @@ ALTER TABLE ONLY public.trial_allowances
 -- Name: trials trials_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.trials
+ALTER TABLE ONLY trials
     ADD CONSTRAINT trials_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: installations unique_github_id_on_installations; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY installations
+    ADD CONSTRAINT unique_github_id_on_installations UNIQUE (github_id);
 
 
 --
 -- Name: urls urls_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.urls
+ALTER TABLE ONLY urls
     ADD CONSTRAINT urls_pkey PRIMARY KEY (id);
 
 
@@ -2697,7 +2699,7 @@ ALTER TABLE ONLY public.urls
 -- Name: user_beta_features user_beta_features_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.user_beta_features
+ALTER TABLE ONLY user_beta_features
     ADD CONSTRAINT user_beta_features_pkey PRIMARY KEY (id);
 
 
@@ -2705,7 +2707,7 @@ ALTER TABLE ONLY public.user_beta_features
 -- Name: users users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.users
+ALTER TABLE ONLY users
     ADD CONSTRAINT users_pkey PRIMARY KEY (id);
 
 
@@ -2713,884 +2715,891 @@ ALTER TABLE ONLY public.users
 -- Name: index_abuses_on_owner; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_abuses_on_owner ON public.abuses USING btree (owner_id);
+CREATE INDEX index_abuses_on_owner ON abuses USING btree (owner_id);
 
 
 --
 -- Name: index_abuses_on_owner_id_and_owner_type_and_level; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_abuses_on_owner_id_and_owner_type_and_level ON public.abuses USING btree (owner_id, owner_type, level);
+CREATE UNIQUE INDEX index_abuses_on_owner_id_and_owner_type_and_level ON abuses USING btree (owner_id, owner_type, level);
 
 
 --
 -- Name: index_branches_on_com_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_branches_on_com_id ON public.branches USING btree (com_id);
+CREATE UNIQUE INDEX index_branches_on_com_id ON branches USING btree (com_id);
 
 
 --
 -- Name: index_branches_on_org_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_branches_on_org_id ON public.branches USING btree (org_id);
+CREATE UNIQUE INDEX index_branches_on_org_id ON branches USING btree (org_id);
 
 
 --
 -- Name: index_branches_on_repository_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_branches_on_repository_id ON public.branches USING btree (repository_id);
+CREATE INDEX index_branches_on_repository_id ON branches USING btree (repository_id);
 
 
 --
 -- Name: index_branches_on_repository_id_and_name_and_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_branches_on_repository_id_and_name_and_id ON public.branches USING btree (repository_id, name, id);
+CREATE INDEX index_branches_on_repository_id_and_name_and_id ON branches USING btree (repository_id, name, id);
 
 
 --
 -- Name: index_broadcasts_on_recipient_id_and_recipient_type; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_broadcasts_on_recipient_id_and_recipient_type ON public.broadcasts USING btree (recipient_id, recipient_type);
+CREATE INDEX index_broadcasts_on_recipient_id_and_recipient_type ON broadcasts USING btree (recipient_id, recipient_type);
 
 
 --
 -- Name: index_build_configs_on_repository_id_and_key; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_build_configs_on_repository_id_and_key ON public.build_configs USING btree (repository_id, key);
+CREATE INDEX index_build_configs_on_repository_id_and_key ON build_configs USING btree (repository_id, key);
 
 
 --
 -- Name: index_builds_on_com_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_builds_on_com_id ON public.builds USING btree (com_id);
+CREATE UNIQUE INDEX index_builds_on_com_id ON builds USING btree (com_id);
 
 
 --
 -- Name: index_builds_on_org_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_builds_on_org_id ON public.builds USING btree (org_id);
+CREATE UNIQUE INDEX index_builds_on_org_id ON builds USING btree (org_id);
 
 
 --
 -- Name: index_builds_on_repository_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_builds_on_repository_id ON public.builds USING btree (repository_id);
+CREATE INDEX index_builds_on_repository_id ON builds USING btree (repository_id);
 
 
 --
 -- Name: index_builds_on_repository_id_and_branch_and_event_type; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_builds_on_repository_id_and_branch_and_event_type ON public.builds USING btree (repository_id, branch, event_type) WHERE ((state)::text = ANY ((ARRAY['created'::character varying, 'queued'::character varying, 'received'::character varying])::text[]));
+CREATE INDEX index_builds_on_repository_id_and_branch_and_event_type ON builds USING btree (repository_id, branch, event_type) WHERE ((state)::text = ANY ((ARRAY['created'::character varying, 'queued'::character varying, 'received'::character varying])::text[]));
 
 
 --
 -- Name: index_builds_on_repository_id_and_branch_and_event_type_and_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_builds_on_repository_id_and_branch_and_event_type_and_id ON public.builds USING btree (repository_id, branch, event_type, id);
+CREATE INDEX index_builds_on_repository_id_and_branch_and_event_type_and_id ON builds USING btree (repository_id, branch, event_type, id);
 
 
 --
 -- Name: index_builds_on_repository_id_and_branch_and_id_desc; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_builds_on_repository_id_and_branch_and_id_desc ON public.builds USING btree (repository_id, branch, id DESC);
+CREATE INDEX index_builds_on_repository_id_and_branch_and_id_desc ON builds USING btree (repository_id, branch, id DESC);
 
 
 --
 -- Name: index_builds_on_repository_id_and_number; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_builds_on_repository_id_and_number ON public.builds USING btree (repository_id, ((number)::integer));
+CREATE INDEX index_builds_on_repository_id_and_number ON builds USING btree (repository_id, ((number)::integer));
 
 
 --
 -- Name: index_builds_on_repository_id_and_number_and_event_type; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_builds_on_repository_id_and_number_and_event_type ON public.builds USING btree (repository_id, number, event_type);
+CREATE INDEX index_builds_on_repository_id_and_number_and_event_type ON builds USING btree (repository_id, number, event_type);
 
 
 --
 -- Name: index_builds_on_repository_id_where_state_not_finished; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_builds_on_repository_id_where_state_not_finished ON public.builds USING btree (repository_id) WHERE ((state)::text = ANY ((ARRAY['created'::character varying, 'queued'::character varying, 'received'::character varying, 'started'::character varying])::text[]));
+CREATE INDEX index_builds_on_repository_id_where_state_not_finished ON builds USING btree (repository_id) WHERE ((state)::text = ANY ((ARRAY['created'::character varying, 'queued'::character varying, 'received'::character varying, 'started'::character varying])::text[]));
 
 
 --
 -- Name: index_builds_on_request_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_builds_on_request_id ON public.builds USING btree (request_id);
+CREATE INDEX index_builds_on_request_id ON builds USING btree (request_id);
 
 
 --
 -- Name: index_builds_on_sender_type_and_sender_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_builds_on_sender_type_and_sender_id ON public.builds USING btree (sender_type, sender_id);
+CREATE INDEX index_builds_on_sender_type_and_sender_id ON builds USING btree (sender_type, sender_id);
 
 
 --
 -- Name: index_builds_on_state; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_builds_on_state ON public.builds USING btree (state);
+CREATE INDEX index_builds_on_state ON builds USING btree (state);
 
 
 --
 -- Name: index_builds_on_updated_at; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_builds_on_updated_at ON public.builds USING btree (updated_at);
+CREATE INDEX index_builds_on_updated_at ON builds USING btree (updated_at);
 
 
 --
 -- Name: index_commits_on_com_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_commits_on_com_id ON public.commits USING btree (com_id);
+CREATE UNIQUE INDEX index_commits_on_com_id ON commits USING btree (com_id);
 
 
 --
 -- Name: index_commits_on_org_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_commits_on_org_id ON public.commits USING btree (org_id);
+CREATE UNIQUE INDEX index_commits_on_org_id ON commits USING btree (org_id);
 
 
 --
 -- Name: index_crons_on_com_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_crons_on_com_id ON public.crons USING btree (com_id);
+CREATE UNIQUE INDEX index_crons_on_com_id ON crons USING btree (com_id);
 
 
 --
 -- Name: index_crons_on_org_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_crons_on_org_id ON public.crons USING btree (org_id);
+CREATE UNIQUE INDEX index_crons_on_org_id ON crons USING btree (org_id);
 
 
 --
 -- Name: index_emails_on_email; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_emails_on_email ON public.emails USING btree (email);
+CREATE INDEX index_emails_on_email ON emails USING btree (email);
 
 
 --
 -- Name: index_emails_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_emails_on_user_id ON public.emails USING btree (user_id);
+CREATE INDEX index_emails_on_user_id ON emails USING btree (user_id);
 
 
 --
 -- Name: index_installations_on_owner_type_and_owner_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_installations_on_owner_type_and_owner_id ON public.installations USING btree (owner_type, owner_id);
+CREATE INDEX index_installations_on_owner_type_and_owner_id ON installations USING btree (owner_type, owner_id);
 
 
 --
 -- Name: index_invoices_on_stripe_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_invoices_on_stripe_id ON public.invoices USING btree (stripe_id);
+CREATE INDEX index_invoices_on_stripe_id ON invoices USING btree (stripe_id);
 
 
 --
 -- Name: index_job_configs_on_repository_id_and_key; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_job_configs_on_repository_id_and_key ON public.job_configs USING btree (repository_id, key);
+CREATE INDEX index_job_configs_on_repository_id_and_key ON job_configs USING btree (repository_id, key);
 
 
 --
 -- Name: index_jobs_on_com_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_jobs_on_com_id ON public.jobs USING btree (com_id);
+CREATE UNIQUE INDEX index_jobs_on_com_id ON jobs USING btree (com_id);
 
 
 --
 -- Name: index_jobs_on_created_at; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_jobs_on_created_at ON public.jobs USING btree (created_at);
+CREATE INDEX index_jobs_on_created_at ON jobs USING btree (created_at);
 
 
 --
 -- Name: index_jobs_on_org_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_jobs_on_org_id ON public.jobs USING btree (org_id);
+CREATE UNIQUE INDEX index_jobs_on_org_id ON jobs USING btree (org_id);
 
 
 --
 -- Name: index_jobs_on_owner_id_and_owner_type_and_state; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_jobs_on_owner_id_and_owner_type_and_state ON public.jobs USING btree (owner_id, owner_type, state);
+CREATE INDEX index_jobs_on_owner_id_and_owner_type_and_state ON jobs USING btree (owner_id, owner_type, state);
 
 
 --
 -- Name: index_jobs_on_repository_id_where_state_running; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_jobs_on_repository_id_where_state_running ON public.jobs USING btree (repository_id) WHERE ((state)::text = ANY ((ARRAY['queued'::character varying, 'received'::character varying, 'started'::character varying])::text[]));
+CREATE INDEX index_jobs_on_repository_id_where_state_running ON jobs USING btree (repository_id) WHERE ((state)::text = ANY ((ARRAY['queued'::character varying, 'received'::character varying, 'started'::character varying])::text[]));
 
 
 --
 -- Name: index_jobs_on_source_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_jobs_on_source_id ON public.jobs USING btree (source_id);
+CREATE INDEX index_jobs_on_source_id ON jobs USING btree (source_id);
 
 
 --
 -- Name: index_jobs_on_stage_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_jobs_on_stage_id ON public.jobs USING btree (stage_id);
+CREATE INDEX index_jobs_on_stage_id ON jobs USING btree (stage_id);
 
 
 --
 -- Name: index_jobs_on_state; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_jobs_on_state ON public.jobs USING btree (state);
+CREATE INDEX index_jobs_on_state ON jobs USING btree (state);
 
 
 --
 -- Name: index_jobs_on_type_and_source_id_and_source_type; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_jobs_on_type_and_source_id_and_source_type ON public.jobs USING btree (type, source_id, source_type);
+CREATE INDEX index_jobs_on_type_and_source_id_and_source_type ON jobs USING btree (type, source_id, source_type);
 
 
 --
 -- Name: index_jobs_on_updated_at; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_jobs_on_updated_at ON public.jobs USING btree (updated_at);
+CREATE INDEX index_jobs_on_updated_at ON jobs USING btree (updated_at);
 
 
 --
 -- Name: index_memberships_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_memberships_on_user_id ON public.memberships USING btree (user_id);
+CREATE INDEX index_memberships_on_user_id ON memberships USING btree (user_id);
 
 
 --
 -- Name: index_messages_on_subject_type_and_subject_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_messages_on_subject_type_and_subject_id ON public.messages USING btree (subject_type, subject_id);
+CREATE INDEX index_messages_on_subject_type_and_subject_id ON messages USING btree (subject_type, subject_id);
 
 
 --
 -- Name: index_organizations_on_com_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_organizations_on_com_id ON public.organizations USING btree (com_id);
+CREATE UNIQUE INDEX index_organizations_on_com_id ON organizations USING btree (com_id);
 
 
 --
 -- Name: index_organizations_on_github_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_organizations_on_github_id ON public.organizations USING btree (github_id);
+CREATE UNIQUE INDEX index_organizations_on_github_id ON organizations USING btree (github_id);
 
 
 --
 -- Name: index_organizations_on_login; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_organizations_on_login ON public.organizations USING btree (login);
+CREATE INDEX index_organizations_on_login ON organizations USING btree (login);
 
 
 --
 -- Name: index_organizations_on_lower_login; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_organizations_on_lower_login ON public.organizations USING btree (lower((login)::text));
+CREATE INDEX index_organizations_on_lower_login ON organizations USING btree (lower((login)::text));
 
 
 --
 -- Name: index_organizations_on_org_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_organizations_on_org_id ON public.organizations USING btree (org_id);
+CREATE UNIQUE INDEX index_organizations_on_org_id ON organizations USING btree (org_id);
 
 
 --
 -- Name: index_organizations_on_updated_at; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_organizations_on_updated_at ON public.organizations USING btree (updated_at);
+CREATE INDEX index_organizations_on_updated_at ON organizations USING btree (updated_at);
 
 
 --
 -- Name: index_owner_groups_on_owner_type_and_owner_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_owner_groups_on_owner_type_and_owner_id ON public.owner_groups USING btree (owner_type, owner_id);
+CREATE INDEX index_owner_groups_on_owner_type_and_owner_id ON owner_groups USING btree (owner_type, owner_id);
 
 
 --
 -- Name: index_owner_groups_on_uuid; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_owner_groups_on_uuid ON public.owner_groups USING btree (uuid);
+CREATE INDEX index_owner_groups_on_uuid ON owner_groups USING btree (uuid);
 
 
 --
 -- Name: index_permissions_on_com_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_permissions_on_com_id ON public.permissions USING btree (com_id);
+CREATE UNIQUE INDEX index_permissions_on_com_id ON permissions USING btree (com_id);
 
 
 --
 -- Name: index_permissions_on_org_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_permissions_on_org_id ON public.permissions USING btree (org_id);
+CREATE UNIQUE INDEX index_permissions_on_org_id ON permissions USING btree (org_id);
 
 
 --
 -- Name: index_permissions_on_repository_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_permissions_on_repository_id ON public.permissions USING btree (repository_id);
+CREATE INDEX index_permissions_on_repository_id ON permissions USING btree (repository_id);
 
 
 --
 -- Name: index_permissions_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_permissions_on_user_id ON public.permissions USING btree (user_id);
+CREATE INDEX index_permissions_on_user_id ON permissions USING btree (user_id);
 
 
 --
 -- Name: index_permissions_on_user_id_and_repository_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_permissions_on_user_id_and_repository_id ON public.permissions USING btree (user_id, repository_id);
+CREATE UNIQUE INDEX index_permissions_on_user_id_and_repository_id ON permissions USING btree (user_id, repository_id);
 
 
 --
 -- Name: index_pull_requests_on_com_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_pull_requests_on_com_id ON public.pull_requests USING btree (com_id);
+CREATE UNIQUE INDEX index_pull_requests_on_com_id ON pull_requests USING btree (com_id);
 
 
 --
 -- Name: index_pull_requests_on_org_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_pull_requests_on_org_id ON public.pull_requests USING btree (org_id);
+CREATE UNIQUE INDEX index_pull_requests_on_org_id ON pull_requests USING btree (org_id);
 
 
 --
 -- Name: index_pull_requests_on_repository_id_and_number; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_pull_requests_on_repository_id_and_number ON public.pull_requests USING btree (repository_id, number);
+CREATE UNIQUE INDEX index_pull_requests_on_repository_id_and_number ON pull_requests USING btree (repository_id, number);
 
 
 --
 -- Name: index_queueable_jobs_on_job_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_queueable_jobs_on_job_id ON public.queueable_jobs USING btree (job_id);
+CREATE INDEX index_queueable_jobs_on_job_id ON queueable_jobs USING btree (job_id);
 
 
 --
 -- Name: index_repo_counts_on_repository_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_repo_counts_on_repository_id ON public.repo_counts USING btree (repository_id);
+CREATE INDEX index_repo_counts_on_repository_id ON repo_counts USING btree (repository_id);
 
 
 --
 -- Name: index_repositories_on_active; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_repositories_on_active ON public.repositories USING btree (active);
+CREATE INDEX index_repositories_on_active ON repositories USING btree (active);
 
 
 --
 -- Name: index_repositories_on_com_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_repositories_on_com_id ON public.repositories USING btree (com_id);
+CREATE UNIQUE INDEX index_repositories_on_com_id ON repositories USING btree (com_id);
 
 
 --
 -- Name: index_repositories_on_github_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_repositories_on_github_id ON public.repositories USING btree (github_id);
+CREATE UNIQUE INDEX index_repositories_on_github_id ON repositories USING btree (github_id);
 
 
 --
 -- Name: index_repositories_on_lower_name; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_repositories_on_lower_name ON public.repositories USING btree (lower((name)::text));
+CREATE INDEX index_repositories_on_lower_name ON repositories USING btree (lower((name)::text));
+
+
+--
+-- Name: index_repositories_on_managed; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_repositories_on_managed ON repositories USING btree (managed_by_installation_at);
 
 
 --
 -- Name: index_repositories_on_name; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_repositories_on_name ON public.repositories USING btree (name);
+CREATE INDEX index_repositories_on_name ON repositories USING btree (name);
 
 
 --
 -- Name: index_repositories_on_org_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_repositories_on_org_id ON public.repositories USING btree (org_id);
+CREATE UNIQUE INDEX index_repositories_on_org_id ON repositories USING btree (org_id);
 
 
 --
 -- Name: index_repositories_on_owner_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_repositories_on_owner_id ON public.repositories USING btree (owner_id);
+CREATE INDEX index_repositories_on_owner_id ON repositories USING btree (owner_id);
 
 
 --
 -- Name: index_repositories_on_owner_name; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_repositories_on_owner_name ON public.repositories USING btree (owner_name);
+CREATE INDEX index_repositories_on_owner_name ON repositories USING btree (owner_name);
 
 
 --
 -- Name: index_repositories_on_slug; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_repositories_on_slug ON public.repositories USING gin (((((owner_name)::text || '/'::text) || (name)::text)) public.gin_trgm_ops);
+CREATE INDEX index_repositories_on_slug ON repositories USING gin (((((owner_name)::text || '/'::text) || (name)::text)) gin_trgm_ops);
 
 
 --
 -- Name: index_repositories_on_updated_at; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_repositories_on_updated_at ON public.repositories USING btree (updated_at);
+CREATE INDEX index_repositories_on_updated_at ON repositories USING btree (updated_at);
 
 
 --
 -- Name: index_request_configs_on_repository_id_and_key; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_request_configs_on_repository_id_and_key ON public.request_configs USING btree (repository_id, key);
+CREATE INDEX index_request_configs_on_repository_id_and_key ON request_configs USING btree (repository_id, key);
 
 
 --
 -- Name: index_request_payloads_on_created_at_and_archived; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_request_payloads_on_created_at_and_archived ON public.request_payloads USING btree (created_at, archived);
+CREATE INDEX index_request_payloads_on_created_at_and_archived ON request_payloads USING btree (created_at, archived);
 
 
 --
 -- Name: index_request_payloads_on_request_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_request_payloads_on_request_id ON public.request_payloads USING btree (request_id);
+CREATE INDEX index_request_payloads_on_request_id ON request_payloads USING btree (request_id);
 
 
 --
 -- Name: index_requests_on_com_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_requests_on_com_id ON public.requests USING btree (com_id);
+CREATE UNIQUE INDEX index_requests_on_com_id ON requests USING btree (com_id);
 
 
 --
 -- Name: index_requests_on_commit_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_requests_on_commit_id ON public.requests USING btree (commit_id);
+CREATE INDEX index_requests_on_commit_id ON requests USING btree (commit_id);
 
 
 --
 -- Name: index_requests_on_created_at; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_requests_on_created_at ON public.requests USING btree (created_at);
+CREATE INDEX index_requests_on_created_at ON requests USING btree (created_at);
 
 
 --
 -- Name: index_requests_on_head_commit; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_requests_on_head_commit ON public.requests USING btree (head_commit);
+CREATE INDEX index_requests_on_head_commit ON requests USING btree (head_commit);
 
 
 --
 -- Name: index_requests_on_org_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_requests_on_org_id ON public.requests USING btree (org_id);
+CREATE UNIQUE INDEX index_requests_on_org_id ON requests USING btree (org_id);
 
 
 --
 -- Name: index_requests_on_repository_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_requests_on_repository_id ON public.requests USING btree (repository_id);
+CREATE INDEX index_requests_on_repository_id ON requests USING btree (repository_id);
 
 
 --
 -- Name: index_requests_on_repository_id_and_id_desc; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_requests_on_repository_id_and_id_desc ON public.requests USING btree (repository_id, id DESC);
+CREATE INDEX index_requests_on_repository_id_and_id_desc ON requests USING btree (repository_id, id DESC);
 
 
 --
 -- Name: index_ssl_key_on_repository_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_ssl_key_on_repository_id ON public.ssl_keys USING btree (repository_id);
+CREATE INDEX index_ssl_key_on_repository_id ON ssl_keys USING btree (repository_id);
 
 
 --
 -- Name: index_ssl_keys_on_com_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_ssl_keys_on_com_id ON public.ssl_keys USING btree (com_id);
+CREATE UNIQUE INDEX index_ssl_keys_on_com_id ON ssl_keys USING btree (com_id);
 
 
 --
 -- Name: index_ssl_keys_on_org_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_ssl_keys_on_org_id ON public.ssl_keys USING btree (org_id);
+CREATE UNIQUE INDEX index_ssl_keys_on_org_id ON ssl_keys USING btree (org_id);
 
 
 --
 -- Name: index_stages_on_build_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_stages_on_build_id ON public.stages USING btree (build_id);
+CREATE INDEX index_stages_on_build_id ON stages USING btree (build_id);
 
 
 --
 -- Name: index_stages_on_com_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_stages_on_com_id ON public.stages USING btree (com_id);
+CREATE UNIQUE INDEX index_stages_on_com_id ON stages USING btree (com_id);
 
 
 --
 -- Name: index_stages_on_org_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_stages_on_org_id ON public.stages USING btree (org_id);
+CREATE UNIQUE INDEX index_stages_on_org_id ON stages USING btree (org_id);
 
 
 --
 -- Name: index_stars_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_stars_on_user_id ON public.stars USING btree (user_id);
+CREATE INDEX index_stars_on_user_id ON stars USING btree (user_id);
 
 
 --
 -- Name: index_stars_on_user_id_and_repository_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_stars_on_user_id_and_repository_id ON public.stars USING btree (user_id, repository_id);
+CREATE UNIQUE INDEX index_stars_on_user_id_and_repository_id ON stars USING btree (user_id, repository_id);
 
 
 --
 -- Name: index_stripe_events_on_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_stripe_events_on_date ON public.stripe_events USING btree (date);
+CREATE INDEX index_stripe_events_on_date ON stripe_events USING btree (date);
 
 
 --
 -- Name: index_stripe_events_on_event_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_stripe_events_on_event_id ON public.stripe_events USING btree (event_id);
+CREATE INDEX index_stripe_events_on_event_id ON stripe_events USING btree (event_id);
 
 
 --
 -- Name: index_stripe_events_on_event_type; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_stripe_events_on_event_type ON public.stripe_events USING btree (event_type);
+CREATE INDEX index_stripe_events_on_event_type ON stripe_events USING btree (event_type);
 
 
 --
 -- Name: index_tags_on_com_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_tags_on_com_id ON public.tags USING btree (com_id);
+CREATE UNIQUE INDEX index_tags_on_com_id ON tags USING btree (com_id);
 
 
 --
 -- Name: index_tags_on_org_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_tags_on_org_id ON public.tags USING btree (org_id);
+CREATE UNIQUE INDEX index_tags_on_org_id ON tags USING btree (org_id);
 
 
 --
 -- Name: index_tags_on_repository_id_and_name; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_tags_on_repository_id_and_name ON public.tags USING btree (repository_id, name);
+CREATE UNIQUE INDEX index_tags_on_repository_id_and_name ON tags USING btree (repository_id, name);
 
 
 --
 -- Name: index_tokens_on_token; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_tokens_on_token ON public.tokens USING btree (token);
+CREATE INDEX index_tokens_on_token ON tokens USING btree (token);
 
 
 --
 -- Name: index_tokens_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_tokens_on_user_id ON public.tokens USING btree (user_id);
+CREATE INDEX index_tokens_on_user_id ON tokens USING btree (user_id);
 
 
 --
 -- Name: index_trial_allowances_on_creator_id_and_creator_type; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_trial_allowances_on_creator_id_and_creator_type ON public.trial_allowances USING btree (creator_id, creator_type);
+CREATE INDEX index_trial_allowances_on_creator_id_and_creator_type ON trial_allowances USING btree (creator_id, creator_type);
 
 
 --
 -- Name: index_trial_allowances_on_trial_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_trial_allowances_on_trial_id ON public.trial_allowances USING btree (trial_id);
+CREATE INDEX index_trial_allowances_on_trial_id ON trial_allowances USING btree (trial_id);
 
 
 --
 -- Name: index_trials_on_owner; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_trials_on_owner ON public.trials USING btree (owner_id, owner_type);
+CREATE INDEX index_trials_on_owner ON trials USING btree (owner_id, owner_type);
 
 
 --
 -- Name: index_user_beta_features_on_user_id_and_beta_feature_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_user_beta_features_on_user_id_and_beta_feature_id ON public.user_beta_features USING btree (user_id, beta_feature_id);
+CREATE INDEX index_user_beta_features_on_user_id_and_beta_feature_id ON user_beta_features USING btree (user_id, beta_feature_id);
 
 
 --
 -- Name: index_users_on_com_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_users_on_com_id ON public.users USING btree (com_id);
+CREATE UNIQUE INDEX index_users_on_com_id ON users USING btree (com_id);
 
 
 --
 -- Name: index_users_on_github_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_users_on_github_id ON public.users USING btree (github_id);
+CREATE UNIQUE INDEX index_users_on_github_id ON users USING btree (github_id);
 
 
 --
 -- Name: index_users_on_github_oauth_token; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_users_on_github_oauth_token ON public.users USING btree (github_oauth_token);
+CREATE UNIQUE INDEX index_users_on_github_oauth_token ON users USING btree (github_oauth_token);
 
 
 --
 -- Name: index_users_on_login; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_users_on_login ON public.users USING btree (login);
+CREATE INDEX index_users_on_login ON users USING btree (login);
 
 
 --
 -- Name: index_users_on_lower_login; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_users_on_lower_login ON public.users USING btree (lower((login)::text));
+CREATE INDEX index_users_on_lower_login ON users USING btree (lower((login)::text));
 
 
 --
 -- Name: index_users_on_org_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_users_on_org_id ON public.users USING btree (org_id);
+CREATE UNIQUE INDEX index_users_on_org_id ON users USING btree (org_id);
 
 
 --
 -- Name: index_users_on_updated_at; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_users_on_updated_at ON public.users USING btree (updated_at);
+CREATE INDEX index_users_on_updated_at ON users USING btree (updated_at);
 
 
 --
 -- Name: subscriptions_owner; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX subscriptions_owner ON public.subscriptions USING btree (owner_id, owner_type) WHERE ((status)::text = 'subscribed'::text);
+CREATE UNIQUE INDEX subscriptions_owner ON subscriptions USING btree (owner_id, owner_type) WHERE ((status)::text = 'subscribed'::text);
 
 
 --
 -- Name: builds set_updated_at_on_builds; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER set_updated_at_on_builds BEFORE INSERT OR UPDATE ON public.builds FOR EACH ROW EXECUTE PROCEDURE public.set_updated_at();
+CREATE TRIGGER set_updated_at_on_builds BEFORE INSERT OR UPDATE ON builds FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
 
 
 --
 -- Name: jobs set_updated_at_on_jobs; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER set_updated_at_on_jobs BEFORE INSERT OR UPDATE ON public.jobs FOR EACH ROW EXECUTE PROCEDURE public.set_updated_at();
+CREATE TRIGGER set_updated_at_on_jobs BEFORE INSERT OR UPDATE ON jobs FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
 
 
 --
 -- Name: branches trg_count_branch_deleted; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER trg_count_branch_deleted AFTER DELETE ON public.branches FOR EACH ROW WHEN ((now() > '2018-01-01 00:00:00+00'::timestamp with time zone)) EXECUTE PROCEDURE public.count_branches('-1');
+CREATE TRIGGER trg_count_branch_deleted AFTER DELETE ON branches FOR EACH ROW WHEN ((now() > '2018-01-01 01:00:00+01'::timestamp with time zone)) EXECUTE PROCEDURE count_branches('-1');
 
 
 --
 -- Name: branches trg_count_branch_inserted; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER trg_count_branch_inserted AFTER INSERT ON public.branches FOR EACH ROW WHEN ((now() > '2018-01-01 00:00:00+00'::timestamp with time zone)) EXECUTE PROCEDURE public.count_branches('1');
+CREATE TRIGGER trg_count_branch_inserted AFTER INSERT ON branches FOR EACH ROW WHEN ((now() > '2018-01-01 01:00:00+01'::timestamp with time zone)) EXECUTE PROCEDURE count_branches('1');
 
 
 --
 -- Name: builds trg_count_build_deleted; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER trg_count_build_deleted AFTER DELETE ON public.builds FOR EACH ROW WHEN ((now() > '2018-01-01 00:00:00+00'::timestamp with time zone)) EXECUTE PROCEDURE public.count_builds('-1');
+CREATE TRIGGER trg_count_build_deleted AFTER DELETE ON builds FOR EACH ROW WHEN ((now() > '2018-01-01 01:00:00+01'::timestamp with time zone)) EXECUTE PROCEDURE count_builds('-1');
 
 
 --
 -- Name: builds trg_count_build_inserted; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER trg_count_build_inserted AFTER INSERT ON public.builds FOR EACH ROW WHEN ((now() > '2018-01-01 00:00:00+00'::timestamp with time zone)) EXECUTE PROCEDURE public.count_builds('1');
+CREATE TRIGGER trg_count_build_inserted AFTER INSERT ON builds FOR EACH ROW WHEN ((now() > '2018-01-01 01:00:00+01'::timestamp with time zone)) EXECUTE PROCEDURE count_builds('1');
 
 
 --
 -- Name: commits trg_count_commit_deleted; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER trg_count_commit_deleted AFTER DELETE ON public.commits FOR EACH ROW WHEN ((now() > '2018-01-01 00:00:00+00'::timestamp with time zone)) EXECUTE PROCEDURE public.count_commits('-1');
+CREATE TRIGGER trg_count_commit_deleted AFTER DELETE ON commits FOR EACH ROW WHEN ((now() > '2018-01-01 01:00:00+01'::timestamp with time zone)) EXECUTE PROCEDURE count_commits('-1');
 
 
 --
 -- Name: commits trg_count_commit_inserted; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER trg_count_commit_inserted AFTER INSERT ON public.commits FOR EACH ROW WHEN ((now() > '2018-01-01 00:00:00+00'::timestamp with time zone)) EXECUTE PROCEDURE public.count_commits('1');
+CREATE TRIGGER trg_count_commit_inserted AFTER INSERT ON commits FOR EACH ROW WHEN ((now() > '2018-01-01 01:00:00+01'::timestamp with time zone)) EXECUTE PROCEDURE count_commits('1');
 
 
 --
 -- Name: jobs trg_count_job_deleted; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER trg_count_job_deleted AFTER DELETE ON public.jobs FOR EACH ROW WHEN ((now() > '2018-01-01 00:00:00+00'::timestamp with time zone)) EXECUTE PROCEDURE public.count_jobs('-1');
+CREATE TRIGGER trg_count_job_deleted AFTER DELETE ON jobs FOR EACH ROW WHEN ((now() > '2018-01-01 01:00:00+01'::timestamp with time zone)) EXECUTE PROCEDURE count_jobs('-1');
 
 
 --
 -- Name: jobs trg_count_job_inserted; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER trg_count_job_inserted AFTER INSERT ON public.jobs FOR EACH ROW WHEN ((now() > '2018-01-01 00:00:00+00'::timestamp with time zone)) EXECUTE PROCEDURE public.count_jobs('1');
+CREATE TRIGGER trg_count_job_inserted AFTER INSERT ON jobs FOR EACH ROW WHEN ((now() > '2018-01-01 01:00:00+01'::timestamp with time zone)) EXECUTE PROCEDURE count_jobs('1');
 
 
 --
 -- Name: pull_requests trg_count_pull_request_deleted; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER trg_count_pull_request_deleted AFTER DELETE ON public.pull_requests FOR EACH ROW WHEN ((now() > '2018-01-01 00:00:00+00'::timestamp with time zone)) EXECUTE PROCEDURE public.count_pull_requests('-1');
+CREATE TRIGGER trg_count_pull_request_deleted AFTER DELETE ON pull_requests FOR EACH ROW WHEN ((now() > '2018-01-01 01:00:00+01'::timestamp with time zone)) EXECUTE PROCEDURE count_pull_requests('-1');
 
 
 --
 -- Name: pull_requests trg_count_pull_request_inserted; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER trg_count_pull_request_inserted AFTER INSERT ON public.pull_requests FOR EACH ROW WHEN ((now() > '2018-01-01 00:00:00+00'::timestamp with time zone)) EXECUTE PROCEDURE public.count_pull_requests('1');
+CREATE TRIGGER trg_count_pull_request_inserted AFTER INSERT ON pull_requests FOR EACH ROW WHEN ((now() > '2018-01-01 01:00:00+01'::timestamp with time zone)) EXECUTE PROCEDURE count_pull_requests('1');
 
 
 --
 -- Name: requests trg_count_request_deleted; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER trg_count_request_deleted AFTER DELETE ON public.requests FOR EACH ROW WHEN ((now() > '2018-01-01 00:00:00+00'::timestamp with time zone)) EXECUTE PROCEDURE public.count_requests('-1');
+CREATE TRIGGER trg_count_request_deleted AFTER DELETE ON requests FOR EACH ROW WHEN ((now() > '2018-01-01 01:00:00+01'::timestamp with time zone)) EXECUTE PROCEDURE count_requests('-1');
 
 
 --
 -- Name: requests trg_count_request_inserted; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER trg_count_request_inserted AFTER INSERT ON public.requests FOR EACH ROW WHEN ((now() > '2018-01-01 00:00:00+00'::timestamp with time zone)) EXECUTE PROCEDURE public.count_requests('1');
+CREATE TRIGGER trg_count_request_inserted AFTER INSERT ON requests FOR EACH ROW WHEN ((now() > '2018-01-01 01:00:00+01'::timestamp with time zone)) EXECUTE PROCEDURE count_requests('1');
 
 
 --
 -- Name: tags trg_count_tag_deleted; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER trg_count_tag_deleted AFTER DELETE ON public.tags FOR EACH ROW WHEN ((now() > '2018-01-01 00:00:00+00'::timestamp with time zone)) EXECUTE PROCEDURE public.count_tags('-1');
+CREATE TRIGGER trg_count_tag_deleted AFTER DELETE ON tags FOR EACH ROW WHEN ((now() > '2018-01-01 01:00:00+01'::timestamp with time zone)) EXECUTE PROCEDURE count_tags('-1');
 
 
 --
 -- Name: tags trg_count_tag_inserted; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER trg_count_tag_inserted AFTER INSERT ON public.tags FOR EACH ROW WHEN ((now() > '2018-01-01 00:00:00+00'::timestamp with time zone)) EXECUTE PROCEDURE public.count_tags('1');
+CREATE TRIGGER trg_count_tag_inserted AFTER INSERT ON tags FOR EACH ROW WHEN ((now() > '2018-01-01 01:00:00+01'::timestamp with time zone)) EXECUTE PROCEDURE count_tags('1');
 
 
 --
 -- Name: installations fk_rails_2d567d406d; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.installations
-    ADD CONSTRAINT fk_rails_2d567d406d FOREIGN KEY (added_by_id) REFERENCES public.users(id);
+ALTER TABLE ONLY installations
+    ADD CONSTRAINT fk_rails_2d567d406d FOREIGN KEY (added_by_id) REFERENCES users(id);
 
 
 --
 -- Name: installations fk_rails_75a0a2a3b4; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.installations
-    ADD CONSTRAINT fk_rails_75a0a2a3b4 FOREIGN KEY (removed_by_id) REFERENCES public.users(id);
+ALTER TABLE ONLY installations
+    ADD CONSTRAINT fk_rails_75a0a2a3b4 FOREIGN KEY (removed_by_id) REFERENCES users(id);
 
 
 --
@@ -3870,6 +3879,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180404000001'),
 ('20180410000000'),
 ('20180413000000'),
-('20180417000000');
+('20180417000000'),
+('20180420000000');
 
 

--- a/db/main/structure.sql
+++ b/db/main/structure.sql
@@ -2704,20 +2704,6 @@ ALTER TABLE ONLY users
 
 
 --
--- Name: favo_2col_uni_idx; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX favo_2col_uni_idx ON installations USING btree (owner_id, owner_type) WHERE (removed_by_id IS NULL);
-
-
---
--- Name: favo_3col_uni_idx; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX favo_3col_uni_idx ON installations USING btree (owner_id, owner_type, removed_by_id) WHERE (removed_by_id IS NOT NULL);
-
-
---
 -- Name: github_id_installations_idx; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -3478,6 +3464,20 @@ CREATE INDEX index_users_on_updated_at ON users USING btree (updated_at);
 --
 
 CREATE INDEX managed_repositories_idx ON repositories USING btree (managed_by_installation_at);
+
+
+--
+-- Name: owner_installations_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX owner_installations_idx ON installations USING btree (owner_id, owner_type) WHERE (removed_by_id IS NULL);
+
+
+--
+-- Name: owner_removed_installations_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX owner_removed_installations_idx ON installations USING btree (owner_id, owner_type, removed_by_id) WHERE (removed_by_id IS NOT NULL);
 
 
 --

--- a/db/main/structure.sql
+++ b/db/main/structure.sql
@@ -2712,6 +2712,20 @@ ALTER TABLE ONLY users
 
 
 --
+-- Name: favo_2col_uni_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX favo_2col_uni_idx ON installations USING btree (owner_id, owner_type) WHERE (removed_by_id IS NULL);
+
+
+--
+-- Name: favo_3col_uni_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX favo_3col_uni_idx ON installations USING btree (owner_id, owner_type, removed_by_id) WHERE (removed_by_id IS NOT NULL);
+
+
+--
 -- Name: index_abuses_on_owner; Type: INDEX; Schema: public; Owner: -
 --
 


### PR DESCRIPTION
Don't know if the changes to structure.sql are an issue here – I ran the migrations against PostgreSQL 9.6.1.

These are both for performance when querying and also to avoid sync creating duplicate records that will be hard to work around later.