### PR TITLE
add an index on jobs (owner_id, owner_type) where state in ('queued', 'received', 'started')

### DIFF
--- a/db/main/migrate/20180501000000_index_jobs_on_owner_where_state_running.rb
+++ b/db/main/migrate/20180501000000_index_jobs_on_owner_where_state_running.rb
@@ -1,0 +1,11 @@
+class IndexJobsOnOwnerWhereStateRunning < ActiveRecord::Migration[4.2]
+  self.disable_ddl_transaction!
+
+  def up
+    execute "CREATE INDEX CONCURRENTLY index_jobs_on_owner_where_state_running ON jobs (owner_id, owner_type) WHERE state IN ('queued', 'received', 'started')"
+  end
+
+  def down
+    execute "DROP INDEX CONCURRENTLY index_jobs_on_owner_where_state_running"
+  end
+end

--- a/db/main/structure.sql
+++ b/db/main/structure.sql
@@ -2963,6 +2963,13 @@ CREATE INDEX index_jobs_on_owner_id_and_owner_type_and_state ON public.jobs USIN
 
 
 --
+-- Name: index_jobs_on_owner_where_state_running; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_jobs_on_owner_where_state_running ON public.jobs USING btree (owner_id, owner_type) WHERE ((state)::text = ANY ((ARRAY['queued'::character varying, 'received'::character varying, 'started'::character varying])::text[]));
+
+
+--
 -- Name: index_jobs_on_repository_id_where_state_running; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -3910,6 +3917,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180420000000'),
 ('20180425000000'),
 ('20180425100000'),
-('20180429000000');
+('20180429000000'),
+('20180501000000');
 
 


### PR DESCRIPTION
this is for two common scheduler queries that were scanning a lot of records and loading 50 megs per call.

this is the query: https://app.pganalyze.com/databases/15694/queries/824910735
old query plan: https://explain.depesz.com/s/Y0Q
new query plan: https://explain.depesz.com/s/iFJh

results:

<img width="1062" alt="screen shot 2018-05-01 at 11 24 02" src="https://user-images.githubusercontent.com/11158255/39468220-470469fa-4d32-11e8-98e8-500316ee003a.png">
<img width="1061" alt="screen shot 2018-05-01 at 11 24 36" src="https://user-images.githubusercontent.com/11158255/39468226-4b49db12-4d32-11e8-9ed0-158c700db384.png">
