### PR TITLE
Run migrations inside container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .ruby-gemset
 log
 *.gem
+vendor

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,5 @@ RUN ruby-install --system --no-install-deps ruby `cat .ruby-version`
 RUN which ruby
 
 # gem setup
-COPY Gemfile .
 RUN apt-get install libpq-dev
 RUN gem install bundler

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM postgres:9.6
+
+RUN mkdir /travis-migrations
+WORKDIR /travis-migrations
+
+# ruby deps
+RUN apt-get update
+RUN apt-get install -y wget build-essential bison zlib1g-dev libyaml-dev libssl1.0-dev libgdbm-dev libreadline-dev libncurses5-dev libffi-dev openssl
+
+# ruby-install
+RUN wget -O ruby-install-0.6.1.tar.gz https://github.com/postmodern/ruby-install/archive/v0.6.1.tar.gz
+RUN tar -xzvf ruby-install-0.6.1.tar.gz
+RUN cd ruby-install-0.6.1/ && make install
+RUN rm -r ruby-install-0.6.1/
+
+# ruby
+COPY .ruby-version .
+RUN ruby-install --system --no-install-deps ruby `cat .ruby-version`
+RUN which ruby
+
+# gem setup
+COPY Gemfile .
+RUN apt-get install libpq-dev
+RUN gem install bundler

--- a/script/dump-schema-docker.sh
+++ b/script/dump-schema-docker.sh
@@ -8,9 +8,10 @@ docker run --name travis-migrations -v `pwd`:/travis-migrations -d -p 5433:5432 
 
 sleep 5
 
-
 docker exec -it travis-migrations psql -U postgres -c "CREATE ROLE root WITH CREATEDB CREATEROLE LOGIN SUPERUSER"
-docker exec -it travis-migrations bundle && (bundle exec rake db:create || true) && bundle exec rake db:migrate db:structure:dump
+docker exec -it travis-migrations bundle install --path ./vendor
+docker exec -it travis-migrations bundle exec rake db:create
+docker exec -it travis-migrations bundle exec rake db:migrate db:structure:dump
 
 docker kill travis-migrations
 docker rm travis-migrations

--- a/script/dump-schema-docker.sh
+++ b/script/dump-schema-docker.sh
@@ -2,16 +2,15 @@
 
 set -e
 
-docker kill postgres-travis-migrations || true
-docker rm postgres-travis-migrations || true
-docker run --name postgres-travis-migrations -d -p 5433:5432 postgres:9.6
+docker kill travis-migrations || true
+docker rm travis-migrations || true
+docker run --name travis-migrations -v `pwd`:/travis-migrations -d -p 5433:5432 travis-migrations:0.1
 
 sleep 5
 
-export DATABASE_URL=postgres://postgres@127.0.0.1:5433/postgres
 
-bundle exec rake db:migrate
-bundle exec rake db:structure:dump
+docker exec -it travis-migrations psql -U postgres -c "CREATE ROLE root WITH CREATEDB CREATEROLE LOGIN SUPERUSER"
+docker exec -it travis-migrations bundle && (bundle exec rake db:create || true) && bundle exec rake db:migrate db:structure:dump
 
-docker kill postgres-travis-migrations
-docker rm postgres-travis-migrations
+docker kill travis-migrations
+docker rm travis-migrations

--- a/script/dump-schema-docker.sh
+++ b/script/dump-schema-docker.sh
@@ -4,7 +4,7 @@ set -e
 
 docker kill travis-migrations || true
 docker rm travis-migrations || true
-docker run --name travis-migrations -v `pwd`:/travis-migrations -d -p 5433:5432 travis-migrations:0.1
+docker run --name travis-migrations -v `pwd`:/travis-migrations -d -p 5433:5432 travisci/travis-migrations:0.1
 
 sleep 5
 

--- a/script/dump-schema-docker.sh
+++ b/script/dump-schema-docker.sh
@@ -4,7 +4,7 @@ set -e
 
 docker kill travis-migrations || true
 docker rm travis-migrations || true
-docker run --name travis-migrations -v `pwd`:/travis-migrations -d -p 5433:5432 travisci/travis-migrations:0.1
+docker run --name travis-migrations -v `pwd`:/travis-migrations -d travisci/travis-migrations:0.1
 
 sleep 5
 


### PR DESCRIPTION
This is still resulting in differences in the stucture.sql file, which is making me question the whole purpose of this PR, but anyway.

```
root@b8848c6d9c47:/travis-migrations# pg_dump --version
pg_dump (PostgreSQL) 9.6.9
```

- [x] Figure out where these new differences come from. Maybe it's 9.6.8 vs 9.6.9?
- [x] Cache gems
- [x] Push image to hub