### PR TITLE
Add repo id to yaml configs

### DIFF
--- a/db/main/migrate/20180531000000_create_request_yaml_configs.rb
+++ b/db/main/migrate/20180531000000_create_request_yaml_configs.rb
@@ -4,9 +4,10 @@ class CreateRequestYamlConfigs < ActiveRecord::Migration[4.2]
   def up
     create_table :request_yaml_configs do |t|
       t.text :yaml
+      t.integer :repository_id
       t.string :key, size: 32, null: false
     end
-    add_index :request_yaml_configs, [:key]
+    add_index :request_yaml_configs, [:repository_id, :key]
     add_column :requests, :yaml_config_id, :integer
   end
 

--- a/db/main/structure.sql
+++ b/db/main/structure.sql
@@ -1644,6 +1644,7 @@ ALTER SEQUENCE public.request_payloads_id_seq OWNED BY public.request_payloads.i
 CREATE TABLE public.request_yaml_configs (
     id integer NOT NULL,
     yaml text,
+    repository_id integer,
     key character varying NOT NULL
 );
 
@@ -3318,10 +3319,10 @@ CREATE INDEX index_request_payloads_on_request_id ON public.request_payloads USI
 
 
 --
--- Name: index_request_yaml_configs_on_key; Type: INDEX; Schema: public; Owner: -
+-- Name: index_request_yaml_configs_on_repository_id_and_key; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_request_yaml_configs_on_key ON public.request_yaml_configs USING btree (key);
+CREATE INDEX index_request_yaml_configs_on_repository_id_and_key ON public.request_yaml_configs USING btree (repository_id, key);
 
 
 --


### PR DESCRIPTION
I forgot to add this column, but it's necessary to make sure we don't de-dupe across repos (and therefore accounts).