### PR TITLE
Drop [requests|builds|jobs].config unless on enterprise

### DIFF
--- a/db/main/migrate/20180410000000_requests_drop_payload.rb
+++ b/db/main/migrate/20180410000000_requests_drop_payload.rb
@@ -1,5 +1,5 @@
 class RequestsDropPayload < ActiveRecord::Migration[4.2]
   def change
-    remove_column :requests, :payload, :text
+    remove_column :requests, :payload, :text unless ENV['TRAVIS_ENTERPRISE']
   end
 end

--- a/db/main/migrate/20180614000000_drop_requests_config.rb
+++ b/db/main/migrate/20180614000000_drop_requests_config.rb
@@ -1,0 +1,8 @@
+class DropRequestsConfig < ActiveRecord::Migration[4.2]
+  def up
+    remove_column :requests, :config unless ENV['TRAVIS_ENTERPRISE']
+  end
+
+  def down
+  end
+end

--- a/db/main/migrate/20180614000001_drop_builds_config.rb
+++ b/db/main/migrate/20180614000001_drop_builds_config.rb
@@ -1,0 +1,8 @@
+class DropBuildsConfig < ActiveRecord::Migration[4.2]
+  def up
+    remove_column :builds, :config unless ENV['TRAVIS_ENTERPRISE']
+  end
+
+  def down
+  end
+end

--- a/db/main/migrate/20180614000002_drop_jobs_config.rb
+++ b/db/main/migrate/20180614000002_drop_jobs_config.rb
@@ -1,0 +1,8 @@
+class DropJobsConfig < ActiveRecord::Migration[4.2]
+  def up
+    remove_column :jobs, :config unless ENV['TRAVIS_ENTERPRISE']
+  end
+
+  def down
+  end
+end


### PR DESCRIPTION
The decision how to deal with backfilling tasks on Enterprise has yet to be made, but this would be a minimal, conservative approach to move this forward.