### PR TITLE
Change email_unsubscribes.id to bigint

### DIFF
--- a/db/main/migrate/20180829000000_make_email_unsubscribes_id_bigint.rb
+++ b/db/main/migrate/20180829000000_make_email_unsubscribes_id_bigint.rb
@@ -1,0 +1,9 @@
+class MakeEmailUnsubscribesIdBigint < ActiveRecord::Migration[4.2]
+  def up
+    change_column :email_unsubscribes, :id, :bigint
+  end
+
+  def down
+    change_column :email_unsubscribes, :id, :integer
+  end
+end

--- a/db/main/structure.sql
+++ b/db/main/structure.sql
@@ -1117,7 +1117,7 @@ ALTER SEQUENCE public.crons_id_seq OWNED BY public.crons.id;
 --
 
 CREATE TABLE public.email_unsubscribes (
-    id integer NOT NULL,
+    id bigint NOT NULL,
     user_id integer,
     repository_id integer,
     created_at timestamp without time zone,
@@ -4270,6 +4270,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180822000000'),
 ('20180823000000'),
 ('20180828000000'),
+('20180829000000'),
 ('20180830000001'),
 ('20180830000002'),
 ('20180830000003'),


### PR DESCRIPTION
As suggested by @igorwwwwwwwwwwwwwwwwwwww in https://github.com/travis-ci/travis-migrations/pull/137#issuecomment-415439315.

Since `users` and `repositories` have regular ints as ids, I left the foreign keys unchanged, any suggestion to do otherwise?

The table is basically empty at this point (just some rows created while testing the feature) so I assume the migration can be run without special care but I'm happy to be corrected about this.