### PR TITLE
Add index on build_emails user preference

### DIFF
--- a/db/main/migrate/20180906000000_add_index_users_preferences_build_emails.rb
+++ b/db/main/migrate/20180906000000_add_index_users_preferences_build_emails.rb
@@ -1,0 +1,17 @@
+class AddIndexUsersPreferencesBuildEmails < ActiveRecord::Migration[4.2]
+  disable_ddl_transaction!
+
+  def up
+    execute <<~sql
+      CREATE INDEX CONCURRENTLY user_preferences_build_emails_false ON users (id) WHERE preferences->>'build_emails' = 'false';
+    sql
+  end
+
+  def down
+    execute <<~sql
+      DROP INDEX CONCURRENTLY user_preferences_build_emails_false;
+    sql
+  end
+end
+
+

--- a/db/main/structure.sql
+++ b/db/main/structure.sql
@@ -3841,6 +3841,13 @@ CREATE UNIQUE INDEX subscriptions_owner ON public.subscriptions USING btree (own
 
 
 --
+-- Name: user_preferences_build_emails_false; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX user_preferences_build_emails_false ON public.users USING btree (id) WHERE ((preferences ->> 'build_emails'::text) = 'false'::text);
+
+
+--
 -- Name: builds set_updated_at_on_builds; Type: TRIGGER; Schema: public; Owner: -
 --
 
@@ -4276,6 +4283,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180830000003'),
 ('20180903000000'),
 ('20180903000001'),
-('20180904000001');
+('20180904000001'),
+('20180906000000');
 
 


### PR DESCRIPTION
In order to prevent the potential performance problem introduced in https://github.com/travis-ci/travis-hub/pull/171, as suggested by @igorwwwwwwwwwwwwwwwwwwww.

The query plan now looks like this:

```
EXPLAIN for: SELECT "emails".* FROM "emails" INNER JOIN "users" ON "users"."id" = "emails"."user_id" WHERE "emails"."email" = 'me@email.com' AND (preferences->>'build_emails' = 'false')
                                                 QUERY PLAN
------------------------------------------------------------------------------------------------------------
 Nested Loop  (cost=4.31..20.86 rows=1 width=56)
   Join Filter: (emails.user_id = users.id)
   ->  Index Only Scan using user_preferences_build_emails_false on users  (cost=0.12..8.14 rows=1 width=4)
   ->  Bitmap Heap Scan on emails  (cost=4.19..12.66 rows=5 width=56)
         Recheck Cond: ((email)::text = 'me@email.com'::text)
         ->  Bitmap Index Scan on index_emails_on_email  (cost=0.00..4.19 rows=5 width=0)
               Index Cond: ((email)::text = 'me@email.com'::text)
```