### PR TITLE
Add gen_migration rake task

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,20 @@ git clone https://github.com/travis-ci/travis-migrations.git
 Adding migrations
 -------------------
 
-To add a migration, create a file and add it to the `db/main/migrate` folder, making sure the filename contains a timestamp later than the one used in the most recent migration file. See [this guide](http://edgeguides.rubyonrails.org/active_record_migrations.html#creating-a-standalone-migration) for creating standalone migrations.
+To add a migration, run the `gen_migration` rake task. For example:
+
+```
+bundle exec rake gen_migration["add_column_x_to_table_y"]
+```
+
+This creates a new ActiveRecord migration file in `db/main/migrate`,
+with the current timestamp and the name `add_column_x_to_table_y`:
+
+```
+      create  db/main/migrate/20181007154333_add_column_x_to_table_y.rb
+```
+
+See [this guide](http://edgeguides.rubyonrails.org/active_record_migrations.html#creating-a-standalone-migration) for creating standalone migrations.
 
 Please make sure your migrations are production safe as per this guide: [Safe Operations For High Volume PostgreSQL](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/).
 

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,7 @@
 require "bundler/setup"
 $:.unshift 'lib'
 require 'travis/migrations'
+require 'rails/generators/active_record/migration/migration_generator'
 
 ActiveRecord::Base.schema_format = :sql
 
@@ -35,4 +36,9 @@ MESSAGE
       end
     end
   end
+end
+
+task :gen_migration, [:name] do |t, args|
+  name = args.fetch(:name)
+  ActiveRecord::Generators::MigrationGenerator.new([name]).create_migration_file
 end


### PR DESCRIPTION
With `rake gen_migration["foo"]`, we generate the migration file
with the name `foo` and the timestamp we need.

This reduces the work needed to created a new migration.