### PR TITLE
Add request_payload_hashes table

### DIFF
--- a/db/main/migrate/2018111312000001_create_request_payload_hashes.rb
+++ b/db/main/migrate/2018111312000001_create_request_payload_hashes.rb
@@ -1,0 +1,14 @@
+class CreateRequestPayloadHashes < ActiveRecord::Migration[4.2]
+  def up
+    create_table :request_payload_hashes, id: false do |t|
+      t.belongs_to :repository, null: false
+      t.text :hash
+    end
+
+    add_index :request_payload_hashes, :hash
+  end
+
+  def down
+    drop_table :request_payload_hashes
+  end
+end

--- a/spec/travis_migrations_spec.rb
+++ b/spec/travis_migrations_spec.rb
@@ -36,6 +36,7 @@ describe 'Rake tasks' do
       repositories
       request_configs
       request_payloads
+      request_payload_hashes
       request_yaml_configs
       requests
       ssl_keys


### PR DESCRIPTION
When we migrate data from .org to .com it's hard to ensure that we don't
loose any requests and that we don't have duplicates without checking if
a GitHub requests has been already processed. It seems that the only way
to say if the request has been already processed is to check whether
there was already a request with the same payload.

In order to keep payload hashes I decided to create a new table. This is
because we will be using it only during the time of transition between
.org and .com, so it will be much easier to delete it afterwards rather
than remove a field.