### PR TITLE
Make branches unique without cleaning up the table

### DIFF
--- a/db/main/migrate/20181203075819_add_set_unique_name_trigger_to_branches.rb
+++ b/db/main/migrate/20181203075819_add_set_unique_name_trigger_to_branches.rb
@@ -1,0 +1,11 @@
+class AddSetUniqueNameTriggerToBranches < ActiveRecord::Migration[5.2]
+  def up
+    add_column :branches, :unique_name, :text
+    execute File.read(Rails.root.join('db/main/sql/triggers/create_set_unique_name.sql'))
+  end
+
+  def down
+    drop_column :branches, :unique_name
+    execute File.read(Rails.root.join('db/main/sql/triggers/drop_set_unique_name.sql'))
+  end
+end

--- a/db/main/migrate/20181203080356_create_index_on_branches_unique_name_and_repository_id.rb
+++ b/db/main/migrate/20181203080356_create_index_on_branches_unique_name_and_repository_id.rb
@@ -1,0 +1,11 @@
+class CreateIndexOnBranchesUniqueNameAndRepositoryId < ActiveRecord::Migration[5.2]
+  self.disable_ddl_transaction!
+
+  def up
+    execute "CREATE UNIQUE INDEX CONCURRENTLY index_branches_repository_id_unique_name ON branches(repository_id, unique_name) WHERE unique_name IS NOT NULL"
+  end
+
+  def down
+    execute "DROP INDEX CONCURRENTLY index_branches_repository_id_unique_name"
+  end
+end

--- a/db/main/sql/triggers/create_set_unique_name.sql
+++ b/db/main/sql/triggers/create_set_unique_name.sql
@@ -1,0 +1,15 @@
+DROP FUNCTION IF EXISTS set_unique_name();
+CREATE FUNCTION set_unique_name() RETURNS trigger AS $$
+BEGIN
+  IF TG_OP = 'INSERT' OR TG_OP = 'UPDATE' THEN
+    NEW.unique_name := NEW.name;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS set_unique_name_on_branches ON branches;
+CREATE TRIGGER set_unique_name_on_branches
+BEFORE INSERT OR UPDATE ON branches
+FOR EACH ROW
+EXECUTE PROCEDURE set_unique_name();

--- a/db/main/sql/triggers/drop_set_unique_name.sql
+++ b/db/main/sql/triggers/drop_set_unique_name.sql
@@ -1,0 +1,4 @@
+DROP TRIGGER IF EXISTS set_updated_at_on_builds on builds;
+DROP TRIGGER IF EXISTS set_updated_at_on_jobs on jobs;
+
+DROP FUNCTION IF EXISTS set_updated_at();

--- a/db/main/structure.sql
+++ b/db/main/structure.sql
@@ -671,6 +671,22 @@ $_$;
 
 
 --
+-- Name: set_unique_name(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION set_unique_name() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+  IF TG_OP = 'INSERT' OR TG_OP = 'UPDATE' THEN
+    NEW.unique_name := NEW.name;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+
+--
 -- Name: set_updated_at(); Type: FUNCTION; Schema: public; Owner: -
 --
 
@@ -786,7 +802,8 @@ CREATE TABLE branches (
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     org_id integer,
-    com_id integer
+    com_id integer,
+    unique_name text
 );
 
 
@@ -2989,10 +3006,24 @@ CREATE INDEX index_branches_on_repository_id ON branches USING btree (repository
 
 
 --
+-- Name: index_branches_on_repository_id_and_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_branches_on_repository_id_and_name ON branches USING btree (repository_id, name);
+
+
+--
 -- Name: index_branches_on_repository_id_and_name_and_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_branches_on_repository_id_and_name_and_id ON branches USING btree (repository_id, name, id);
+
+
+--
+-- Name: index_branches_repository_id_unique_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_branches_repository_id_unique_name ON branches USING btree (repository_id, unique_name) WHERE (unique_name IS NOT NULL);
 
 
 --
@@ -3997,6 +4028,13 @@ CREATE INDEX user_preferences_build_emails_false ON users USING btree (id) WHERE
 
 
 --
+-- Name: branches set_unique_name_on_branches; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER set_unique_name_on_branches BEFORE INSERT OR UPDATE ON branches FOR EACH ROW EXECUTE PROCEDURE set_unique_name();
+
+
+--
 -- Name: builds set_updated_at_on_builds; Type: TRIGGER; Schema: public; Owner: -
 --
 
@@ -4688,6 +4726,9 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20181029120000'),
 ('20181116800000'),
 ('20181116800001'),
-('20181126080000');
+('20181126080000'),
+('20181128120000'),
+('20181203075819'),
+('20181203080356');
 
 

--- a/spec/set_unique_name_spec.rb
+++ b/spec/set_unique_name_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+require 'yaml'
+
+describe 'set_updated_at trigger' do
+  def run(cmd)
+    system "RAILS_ENV=test bundle exec #{cmd}"
+    expect($?.exitstatus).to eq 0
+  end
+
+  let(:config) { YAML.load(ERB.new(File.read('config/database.yml')).result) }
+  before(:all) do
+    run 'rake db:drop db:create db:migrate'
+  end
+
+  before { ActiveRecord::Base.establish_connection(config['test']) }
+  after { ActiveRecord::Base.remove_connection }
+
+  before do
+    conn.execute('TRUNCATE branches CASCADE;')
+  end
+
+  let(:conn)   { ActiveRecord::Base.connection }
+
+  def e(query)
+    conn.execute(query)
+  end
+
+  def s(query)
+    conn.select_one(query)
+  end
+
+  it 'sets unique_name on INSERT' do
+    e "INSERT INTO repositories (id, created_at, updated_at) VALUES(1, now(), now())"
+    e "INSERT INTO branches (repository_id, name, created_at, updated_at) VALUES (1, 'main', now(), now());"
+    result = s "SELECT name FROM branches"
+    expect(result['name']).to eql('main')
+  end
+
+  it 'sets unique_name on UPDATE' do
+    e "INSERT INTO repositories (id, created_at, updated_at) VALUES(1, now(), now())"
+    e "INSERT INTO branches (repository_id, name, created_at, updated_at) VALUES (1, 'main', now(), now());"
+    e "UPDATE branches SET name = 'foo';"
+    result = s "SELECT unique_name FROM branches"
+    expect(result['unique_name']).to eql('foo')
+  end
+
+  it 'enforces the index' do
+    e "INSERT INTO repositories (id, created_at, updated_at) VALUES(1, now(), now())"
+    e "INSERT INTO branches (repository_id, name, created_at, updated_at) VALUES (1, 'main', now(), now());"
+    expect {
+    e "INSERT INTO branches (repository_id, name, created_at, updated_at) VALUES (1, 'main', now(), now());"
+    }.to raise_error(ActiveRecord::RecordNotUnique)
+
+    e "INSERT INTO branches (repository_id, name, created_at, updated_at) VALUES (1, 'something-else', now(), now());"
+    expect {
+      e "UPDATE branches SET name = 'main';"
+    }.to raise_error(ActiveRecord::RecordNotUnique)
+  end
+end


### PR DESCRIPTION
We have a problem with the code in gatekeeper and possibly API
introducing duplicated branches. We want to add an index on
`(repository_id, name)`, but we need to clean the table first and in
order to do that we need to fix the bug, so no new duplicates are
introduced during index creation. Otherwise we would have to use a
maintenance window for index creation and stop all the apps from
processing, which would be much harder operationally and add a
considerable delay.

In this commit I introduce a simple way to overcome the problem. A new
column `unique_name` is added to branches. The column is set on UPDATEs
and INSERTs to the branches table with a value of the `name` column. An
index is also added on `(repository_id, unique_name) WHERE unique_name
IS NOT NULL`, which enforces an index on any new or updated branches
when `unique_name` is not NULL.