### PR TITLE
Add unique index to crons on branch_id

### DIFF
--- a/db/main/migrate/20181205152712_add_unique_index_to_crons_on_branch_id.rb
+++ b/db/main/migrate/20181205152712_add_unique_index_to_crons_on_branch_id.rb
@@ -1,4 +1,4 @@
-class add_unique_index_to_crons_on_branch_id < ActiveRecord::Migration[4.2]
+class AddUniqueIndexToCronsOnBranchId < ActiveRecord::Migration[4.2]
   self.disable_ddl_transaction!
 
   def up

--- a/db/main/migrate/20181205152712_add_unique_index_to_crons_on_branch_id.rb
+++ b/db/main/migrate/20181205152712_add_unique_index_to_crons_on_branch_id.rb
@@ -1,0 +1,12 @@
+class add_unique_index_to_crons_on_branch_id < ActiveRecord::Migration[4.2]
+  self.disable_ddl_transaction!
+
+  def up
+    execute "DROP INDEX CONCURRENTLY index_crons_on_branch_id"
+    execute "CREATE UNIQUE INDEX CONCURRENTLY index_crons_on_branch_id ON crons(branch_id)"
+  end
+
+  def down
+    execute "DROP INDEX CONCURRENTLY index_crons_on_branch_id"
+  end
+end


### PR DESCRIPTION
There is currently an index on `branch_id`, but it's not unique. Ecto
requires this in order to deal with conflicts on upserts. Also, this is
my understanding of what our current business logic is; there are
currently no duplicate branches, which seems to confirm that this is the
desired behavior.