### PR TITLE
Make subscription owner fields not nullable

### DIFF
--- a/db/main/migrate/20190204000000_make_subscription_owner_not_nullable.rb
+++ b/db/main/migrate/20190204000000_make_subscription_owner_not_nullable.rb
@@ -1,0 +1,6 @@
+class MakeSubscriptionOwnerNotNullable < ActiveRecord::Migration[4.2]
+  def change
+    change_column_null :subscriptions, :owner_type, false
+    change_column_null :subscriptions, :owner_id, false
+  end
+end

--- a/db/main/structure.sql
+++ b/db/main/structure.sql
@@ -2075,8 +2075,8 @@ CREATE TABLE public.subscriptions (
     id integer NOT NULL,
     cc_token character varying,
     valid_to timestamp without time zone,
-    owner_type character varying,
-    owner_id integer,
+    owner_type character varying NOT NULL,
+    owner_id integer NOT NULL,
     first_name character varying,
     last_name character varying,
     company character varying,
@@ -4803,6 +4803,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190102000000'),
 ('20190102000001'),
 ('20190109000000'),
-('20190118000000');
+('20190118000000'),
+('20190204000000');
 
 


### PR DESCRIPTION
Note: this migration will FAIL if run because there are currently rows where
this field is NULL (and this is the point of this change). Adding a default
makes no sense in this case, so those rows need to be dealt with before
deploying this change.