### PR TITLE
Add a unique_number column, unique index and triggers

### DIFF
--- a/db/main/migrate/20190409133118_add_unique_number_column_to_builds.rb
+++ b/db/main/migrate/20190409133118_add_unique_number_column_to_builds.rb
@@ -1,0 +1,5 @@
+class AddUniqueNumberColumnToBuilds < ActiveRecord::Migration[5.2]
+  def change
+    add_column :builds, :unique_number, :int
+  end
+end

--- a/db/main/migrate/20190409133320_add_set_unique_number_trigger_to_builds.rb
+++ b/db/main/migrate/20190409133320_add_set_unique_number_trigger_to_builds.rb
@@ -1,0 +1,9 @@
+class AddSetUniqueNumberTriggerToBuilds < ActiveRecord::Migration[5.2]
+  def up
+    execute File.read(Rails.root.join('db/main/sql/triggers/create_set_unique_number.sql'))
+  end
+
+  def down
+    execute File.read(Rails.root.join('db/main/sql/triggers/drop_set_unique_number.sql'))
+  end
+end

--- a/db/main/migrate/20190409133444_create_unique_index_on_repository_id_and_number_on_builds.rb
+++ b/db/main/migrate/20190409133444_create_unique_index_on_repository_id_and_number_on_builds.rb
@@ -1,0 +1,11 @@
+class CreateUniqueIndexOnRepositoryIdAndNumberOnBuilds < ActiveRecord::Migration[5.2]
+  self.disable_ddl_transaction!
+
+  def up
+    execute "CREATE UNIQUE INDEX CONCURRENTLY index_builds_repository_id_unique_number ON builds(repository_id, unique_number) WHERE unique_number IS NOT NULL"
+  end
+
+  def down
+    execute "DROP INDEX CONCURRENTLY index_builds_repository_id_unique_number"
+  end
+end

--- a/db/main/sql/triggers/create_set_unique_number.sql
+++ b/db/main/sql/triggers/create_set_unique_number.sql
@@ -1,0 +1,27 @@
+DROP TRIGGER IF EXISTS set_unique_number_on_builds ON builds;
+DROP FUNCTION IF EXISTS set_unique_number();
+CREATE FUNCTION set_unique_number() RETURNS trigger AS $$
+DECLARE
+  disable boolean;
+BEGIN
+  disable := 'f';
+  IF TG_OP = 'INSERT' OR TG_OP = 'UPDATE' THEN
+    BEGIN
+       disable := current_setting('set_unique_number_on_builds.disable');
+    EXCEPTION
+    WHEN others THEN
+      set set_unique_number_on_builds.disable = 'f';
+    END;
+
+    IF NOT disable THEN
+      NEW.unique_number := NEW.number;
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER set_unique_number_on_builds
+BEFORE INSERT OR UPDATE ON builds
+FOR EACH ROW
+EXECUTE PROCEDURE set_unique_number();

--- a/db/main/sql/triggers/drop_set_unique_number.sql
+++ b/db/main/sql/triggers/drop_set_unique_number.sql
@@ -1,0 +1,2 @@
+DROP TRIGGER IF EXISTS set_unique_number_on_builds ON builds;
+DROP FUNCTION IF EXISTS set_unique_number();

--- a/db/main/structure.sql
+++ b/db/main/structure.sql
@@ -3,23 +3,10 @@ SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
 SET client_min_messages = warning;
 SET row_security = off;
-
---
--- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
-
-
---
--- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
-
 
 --
 -- Name: pg_trgm; Type: EXTENSION; Schema: -; Owner: -
@@ -49,13 +36,11 @@ CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public;
 COMMENT ON EXTENSION pgcrypto IS 'cryptographic functions';
 
 
-SET search_path = public, pg_catalog;
-
 --
 -- Name: source_type; Type: TYPE; Schema: public; Owner: -
 --
 
-CREATE TYPE source_type AS ENUM (
+CREATE TYPE public.source_type AS ENUM (
     'manual',
     'stripe',
     'github',
@@ -67,7 +52,7 @@ CREATE TYPE source_type AS ENUM (
 -- Name: agg_all_repo_counts(); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION agg_all_repo_counts() RETURNS boolean
+CREATE FUNCTION public.agg_all_repo_counts() RETURNS boolean
     LANGUAGE plpgsql
     AS $$
 begin
@@ -129,7 +114,7 @@ $$;
 -- Name: agg_repo_counts(integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION agg_repo_counts(_repo_id integer) RETURNS boolean
+CREATE FUNCTION public.agg_repo_counts(_repo_id integer) RETURNS boolean
     LANGUAGE plpgsql
     AS $$
 begin
@@ -193,7 +178,7 @@ $$;
 -- Name: count_all_branches(integer, integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION count_all_branches(_count integer, _start integer, _end integer) RETURNS boolean
+CREATE FUNCTION public.count_all_branches(_count integer, _start integer, _end integer) RETURNS boolean
     LANGUAGE plpgsql
     AS $$
 declare max int;
@@ -218,7 +203,7 @@ $$;
 -- Name: count_all_builds(integer, integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION count_all_builds(_count integer, _start integer, _end integer) RETURNS boolean
+CREATE FUNCTION public.count_all_builds(_count integer, _start integer, _end integer) RETURNS boolean
     LANGUAGE plpgsql
     AS $$
 declare max int;
@@ -243,7 +228,7 @@ $$;
 -- Name: count_all_commits(integer, integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION count_all_commits(_count integer, _start integer, _end integer) RETURNS boolean
+CREATE FUNCTION public.count_all_commits(_count integer, _start integer, _end integer) RETURNS boolean
     LANGUAGE plpgsql
     AS $$
 declare max int;
@@ -268,7 +253,7 @@ $$;
 -- Name: count_all_jobs(integer, integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION count_all_jobs(_count integer, _start integer, _end integer) RETURNS boolean
+CREATE FUNCTION public.count_all_jobs(_count integer, _start integer, _end integer) RETURNS boolean
     LANGUAGE plpgsql
     AS $$
 declare max int;
@@ -293,7 +278,7 @@ $$;
 -- Name: count_all_pull_requests(integer, integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION count_all_pull_requests(_count integer, _start integer, _end integer) RETURNS boolean
+CREATE FUNCTION public.count_all_pull_requests(_count integer, _start integer, _end integer) RETURNS boolean
     LANGUAGE plpgsql
     AS $$
 declare max int;
@@ -318,7 +303,7 @@ $$;
 -- Name: count_all_requests(integer, integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION count_all_requests(_count integer, _start integer, _end integer) RETURNS boolean
+CREATE FUNCTION public.count_all_requests(_count integer, _start integer, _end integer) RETURNS boolean
     LANGUAGE plpgsql
     AS $$
 declare max int;
@@ -342,7 +327,7 @@ $$;
 -- Name: count_all_tags(integer, integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION count_all_tags(_count integer, _start integer, _end integer) RETURNS boolean
+CREATE FUNCTION public.count_all_tags(_count integer, _start integer, _end integer) RETURNS boolean
     LANGUAGE plpgsql
     AS $$
 declare max int;
@@ -367,7 +352,7 @@ $$;
 -- Name: count_branches(); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION count_branches() RETURNS trigger
+CREATE FUNCTION public.count_branches() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 declare
@@ -392,7 +377,7 @@ $$;
 -- Name: count_branches(integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION count_branches(_start integer, _end integer) RETURNS TABLE(repository_id integer, branches bigint, range character varying)
+CREATE FUNCTION public.count_branches(_start integer, _end integer) RETURNS TABLE(repository_id integer, branches bigint, range character varying)
     LANGUAGE plpgsql
     AS $$
 begin
@@ -409,7 +394,7 @@ $$;
 -- Name: count_builds(); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION count_builds() RETURNS trigger
+CREATE FUNCTION public.count_builds() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 declare
@@ -434,7 +419,7 @@ $$;
 -- Name: count_builds(integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION count_builds(_start integer, _end integer) RETURNS TABLE(repository_id integer, builds bigint, range character varying)
+CREATE FUNCTION public.count_builds(_start integer, _end integer) RETURNS TABLE(repository_id integer, builds bigint, range character varying)
     LANGUAGE plpgsql
     AS $$
 begin
@@ -450,7 +435,7 @@ $$;
 -- Name: count_commits(); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION count_commits() RETURNS trigger
+CREATE FUNCTION public.count_commits() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 declare
@@ -475,7 +460,7 @@ $$;
 -- Name: count_commits(integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION count_commits(_start integer, _end integer) RETURNS TABLE(repository_id integer, commits bigint, range character varying)
+CREATE FUNCTION public.count_commits(_start integer, _end integer) RETURNS TABLE(repository_id integer, commits bigint, range character varying)
     LANGUAGE plpgsql
     AS $$
 begin
@@ -492,7 +477,7 @@ $$;
 -- Name: count_jobs(); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION count_jobs() RETURNS trigger
+CREATE FUNCTION public.count_jobs() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 declare
@@ -517,7 +502,7 @@ $$;
 -- Name: count_jobs(integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION count_jobs(_start integer, _end integer) RETURNS TABLE(repository_id integer, jobs bigint, range character varying)
+CREATE FUNCTION public.count_jobs(_start integer, _end integer) RETURNS TABLE(repository_id integer, jobs bigint, range character varying)
     LANGUAGE plpgsql
     AS $$
 begin
@@ -533,7 +518,7 @@ $$;
 -- Name: count_pull_requests(); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION count_pull_requests() RETURNS trigger
+CREATE FUNCTION public.count_pull_requests() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 declare
@@ -558,7 +543,7 @@ $$;
 -- Name: count_pull_requests(integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION count_pull_requests(_start integer, _end integer) RETURNS TABLE(repository_id integer, pull_requests bigint, range character varying)
+CREATE FUNCTION public.count_pull_requests(_start integer, _end integer) RETURNS TABLE(repository_id integer, pull_requests bigint, range character varying)
     LANGUAGE plpgsql
     AS $$
 begin
@@ -575,7 +560,7 @@ $$;
 -- Name: count_requests(); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION count_requests() RETURNS trigger
+CREATE FUNCTION public.count_requests() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 declare
@@ -600,7 +585,7 @@ $$;
 -- Name: count_requests(integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION count_requests(_start integer, _end integer) RETURNS TABLE(repository_id integer, requests bigint, range character varying)
+CREATE FUNCTION public.count_requests(_start integer, _end integer) RETURNS TABLE(repository_id integer, requests bigint, range character varying)
     LANGUAGE plpgsql
     AS $$
 begin
@@ -616,7 +601,7 @@ $$;
 -- Name: count_tags(); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION count_tags() RETURNS trigger
+CREATE FUNCTION public.count_tags() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 declare
@@ -641,7 +626,7 @@ $$;
 -- Name: count_tags(integer, integer); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION count_tags(_start integer, _end integer) RETURNS TABLE(repository_id integer, tags bigint, range character varying)
+CREATE FUNCTION public.count_tags(_start integer, _end integer) RETURNS TABLE(repository_id integer, tags bigint, range character varying)
     LANGUAGE plpgsql
     AS $$
 begin
@@ -658,7 +643,7 @@ $$;
 -- Name: is_json(text); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION is_json(text) RETURNS boolean
+CREATE FUNCTION public.is_json(text) RETURNS boolean
     LANGUAGE plpgsql IMMUTABLE
     AS $_$
   BEGIN
@@ -674,7 +659,7 @@ $_$;
 -- Name: set_unique_name(); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION set_unique_name() RETURNS trigger
+CREATE FUNCTION public.set_unique_name() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 DECLARE
@@ -699,10 +684,38 @@ $$;
 
 
 --
+-- Name: set_unique_number(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.set_unique_number() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+  disable boolean;
+BEGIN
+  disable := 'f';
+  IF TG_OP = 'INSERT' OR TG_OP = 'UPDATE' THEN
+    BEGIN
+       disable := current_setting('set_unique_number_on_builds.disable');
+    EXCEPTION
+    WHEN others THEN
+      set set_unique_number_on_builds.disable = 'f';
+    END;
+
+    IF NOT disable THEN
+      NEW.unique_number := NEW.number;
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+
+--
 -- Name: set_updated_at(); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION set_updated_at() RETURNS trigger
+CREATE FUNCTION public.set_updated_at() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
       BEGIN
@@ -723,7 +736,7 @@ SET default_with_oids = false;
 -- Name: abuses; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE abuses (
+CREATE TABLE public.abuses (
     id integer NOT NULL,
     owner_type character varying,
     owner_id integer,
@@ -739,7 +752,7 @@ CREATE TABLE abuses (
 -- Name: abuses_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE abuses_id_seq
+CREATE SEQUENCE public.abuses_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -751,14 +764,14 @@ CREATE SEQUENCE abuses_id_seq
 -- Name: abuses_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE abuses_id_seq OWNED BY abuses.id;
+ALTER SEQUENCE public.abuses_id_seq OWNED BY public.abuses.id;
 
 
 --
 -- Name: ar_internal_metadata; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE ar_internal_metadata (
+CREATE TABLE public.ar_internal_metadata (
     key character varying NOT NULL,
     value character varying,
     created_at timestamp without time zone NOT NULL,
@@ -770,7 +783,7 @@ CREATE TABLE ar_internal_metadata (
 -- Name: beta_features; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE beta_features (
+CREATE TABLE public.beta_features (
     id integer NOT NULL,
     name character varying,
     description text,
@@ -786,7 +799,7 @@ CREATE TABLE beta_features (
 -- Name: beta_features_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE beta_features_id_seq
+CREATE SEQUENCE public.beta_features_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -798,14 +811,14 @@ CREATE SEQUENCE beta_features_id_seq
 -- Name: beta_features_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE beta_features_id_seq OWNED BY beta_features.id;
+ALTER SEQUENCE public.beta_features_id_seq OWNED BY public.beta_features.id;
 
 
 --
 -- Name: beta_migration_requests; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE beta_migration_requests (
+CREATE TABLE public.beta_migration_requests (
     id integer NOT NULL,
     owner_id integer,
     owner_name character varying,
@@ -819,7 +832,7 @@ CREATE TABLE beta_migration_requests (
 -- Name: beta_migration_requests_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE beta_migration_requests_id_seq
+CREATE SEQUENCE public.beta_migration_requests_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -831,14 +844,14 @@ CREATE SEQUENCE beta_migration_requests_id_seq
 -- Name: beta_migration_requests_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE beta_migration_requests_id_seq OWNED BY beta_migration_requests.id;
+ALTER SEQUENCE public.beta_migration_requests_id_seq OWNED BY public.beta_migration_requests.id;
 
 
 --
 -- Name: branches; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE branches (
+CREATE TABLE public.branches (
     id integer NOT NULL,
     repository_id integer NOT NULL,
     last_build_id integer,
@@ -856,7 +869,7 @@ CREATE TABLE branches (
 -- Name: branches_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE branches_id_seq
+CREATE SEQUENCE public.branches_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -868,14 +881,14 @@ CREATE SEQUENCE branches_id_seq
 -- Name: branches_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE branches_id_seq OWNED BY branches.id;
+ALTER SEQUENCE public.branches_id_seq OWNED BY public.branches.id;
 
 
 --
 -- Name: broadcasts; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE broadcasts (
+CREATE TABLE public.broadcasts (
     id integer NOT NULL,
     recipient_type character varying,
     recipient_id integer,
@@ -892,7 +905,7 @@ CREATE TABLE broadcasts (
 -- Name: broadcasts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE broadcasts_id_seq
+CREATE SEQUENCE public.broadcasts_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -904,14 +917,14 @@ CREATE SEQUENCE broadcasts_id_seq
 -- Name: broadcasts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE broadcasts_id_seq OWNED BY broadcasts.id;
+ALTER SEQUENCE public.broadcasts_id_seq OWNED BY public.broadcasts.id;
 
 
 --
 -- Name: build_configs; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE build_configs (
+CREATE TABLE public.build_configs (
     id integer NOT NULL,
     repository_id integer NOT NULL,
     key character varying NOT NULL,
@@ -923,7 +936,7 @@ CREATE TABLE build_configs (
 -- Name: build_configs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE build_configs_id_seq
+CREATE SEQUENCE public.build_configs_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -935,14 +948,14 @@ CREATE SEQUENCE build_configs_id_seq
 -- Name: build_configs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE build_configs_id_seq OWNED BY build_configs.id;
+ALTER SEQUENCE public.build_configs_id_seq OWNED BY public.build_configs.id;
 
 
 --
 -- Name: shared_builds_tasks_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE shared_builds_tasks_seq
+CREATE SEQUENCE public.shared_builds_tasks_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -954,8 +967,8 @@ CREATE SEQUENCE shared_builds_tasks_seq
 -- Name: builds; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE builds (
-    id bigint DEFAULT nextval('shared_builds_tasks_seq'::regclass) NOT NULL,
+CREATE TABLE public.builds (
+    id bigint DEFAULT nextval('public.shared_builds_tasks_seq'::regclass) NOT NULL,
     repository_id integer,
     number character varying,
     started_at timestamp without time zone,
@@ -996,7 +1009,8 @@ CREATE TABLE builds (
     org_id integer,
     com_id integer,
     config_id integer,
-    restarted_at timestamp without time zone
+    restarted_at timestamp without time zone,
+    unique_number integer
 );
 
 
@@ -1004,7 +1018,7 @@ CREATE TABLE builds (
 -- Name: builds_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE builds_id_seq
+CREATE SEQUENCE public.builds_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1016,14 +1030,14 @@ CREATE SEQUENCE builds_id_seq
 -- Name: builds_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE builds_id_seq OWNED BY builds.id;
+ALTER SEQUENCE public.builds_id_seq OWNED BY public.builds.id;
 
 
 --
 -- Name: cancellations; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE cancellations (
+CREATE TABLE public.cancellations (
     id integer NOT NULL,
     subscription_id integer NOT NULL,
     user_id integer,
@@ -1041,7 +1055,7 @@ CREATE TABLE cancellations (
 -- Name: cancellations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE cancellations_id_seq
+CREATE SEQUENCE public.cancellations_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1053,14 +1067,14 @@ CREATE SEQUENCE cancellations_id_seq
 -- Name: cancellations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE cancellations_id_seq OWNED BY cancellations.id;
+ALTER SEQUENCE public.cancellations_id_seq OWNED BY public.cancellations.id;
 
 
 --
 -- Name: commits; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE commits (
+CREATE TABLE public.commits (
     id integer NOT NULL,
     repository_id integer,
     commit character varying,
@@ -1086,7 +1100,7 @@ CREATE TABLE commits (
 -- Name: commits_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE commits_id_seq
+CREATE SEQUENCE public.commits_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1098,14 +1112,14 @@ CREATE SEQUENCE commits_id_seq
 -- Name: commits_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE commits_id_seq OWNED BY commits.id;
+ALTER SEQUENCE public.commits_id_seq OWNED BY public.commits.id;
 
 
 --
 -- Name: coupons; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE coupons (
+CREATE TABLE public.coupons (
     id integer NOT NULL,
     percent_off integer,
     coupon_id character varying,
@@ -1122,7 +1136,7 @@ CREATE TABLE coupons (
 -- Name: coupons_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE coupons_id_seq
+CREATE SEQUENCE public.coupons_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1134,14 +1148,14 @@ CREATE SEQUENCE coupons_id_seq
 -- Name: coupons_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE coupons_id_seq OWNED BY coupons.id;
+ALTER SEQUENCE public.coupons_id_seq OWNED BY public.coupons.id;
 
 
 --
 -- Name: crons; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE crons (
+CREATE TABLE public.crons (
     id integer NOT NULL,
     branch_id integer,
     "interval" character varying NOT NULL,
@@ -1160,7 +1174,7 @@ CREATE TABLE crons (
 -- Name: crons_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE crons_id_seq
+CREATE SEQUENCE public.crons_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1172,14 +1186,14 @@ CREATE SEQUENCE crons_id_seq
 -- Name: crons_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE crons_id_seq OWNED BY crons.id;
+ALTER SEQUENCE public.crons_id_seq OWNED BY public.crons.id;
 
 
 --
 -- Name: email_unsubscribes; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE email_unsubscribes (
+CREATE TABLE public.email_unsubscribes (
     id bigint NOT NULL,
     user_id integer,
     repository_id integer,
@@ -1192,7 +1206,7 @@ CREATE TABLE email_unsubscribes (
 -- Name: email_unsubscribes_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE email_unsubscribes_id_seq
+CREATE SEQUENCE public.email_unsubscribes_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1204,14 +1218,14 @@ CREATE SEQUENCE email_unsubscribes_id_seq
 -- Name: email_unsubscribes_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE email_unsubscribes_id_seq OWNED BY email_unsubscribes.id;
+ALTER SEQUENCE public.email_unsubscribes_id_seq OWNED BY public.email_unsubscribes.id;
 
 
 --
 -- Name: emails; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE emails (
+CREATE TABLE public.emails (
     id integer NOT NULL,
     user_id integer,
     email character varying,
@@ -1224,7 +1238,7 @@ CREATE TABLE emails (
 -- Name: emails_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE emails_id_seq
+CREATE SEQUENCE public.emails_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1236,14 +1250,14 @@ CREATE SEQUENCE emails_id_seq
 -- Name: emails_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE emails_id_seq OWNED BY emails.id;
+ALTER SEQUENCE public.emails_id_seq OWNED BY public.emails.id;
 
 
 --
 -- Name: gatekeeper_workers; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE gatekeeper_workers (
+CREATE TABLE public.gatekeeper_workers (
     id bigint NOT NULL
 );
 
@@ -1252,7 +1266,7 @@ CREATE TABLE gatekeeper_workers (
 -- Name: gatekeeper_workers_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE gatekeeper_workers_id_seq
+CREATE SEQUENCE public.gatekeeper_workers_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1264,14 +1278,14 @@ CREATE SEQUENCE gatekeeper_workers_id_seq
 -- Name: gatekeeper_workers_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE gatekeeper_workers_id_seq OWNED BY gatekeeper_workers.id;
+ALTER SEQUENCE public.gatekeeper_workers_id_seq OWNED BY public.gatekeeper_workers.id;
 
 
 --
 -- Name: installations; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE installations (
+CREATE TABLE public.installations (
     id integer NOT NULL,
     github_id integer,
     permissions jsonb,
@@ -1289,7 +1303,7 @@ CREATE TABLE installations (
 -- Name: installations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE installations_id_seq
+CREATE SEQUENCE public.installations_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1301,14 +1315,14 @@ CREATE SEQUENCE installations_id_seq
 -- Name: installations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE installations_id_seq OWNED BY installations.id;
+ALTER SEQUENCE public.installations_id_seq OWNED BY public.installations.id;
 
 
 --
 -- Name: invoices; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE invoices (
+CREATE TABLE public.invoices (
     id integer NOT NULL,
     object text,
     created_at timestamp without time zone,
@@ -1324,7 +1338,7 @@ CREATE TABLE invoices (
 -- Name: invoices_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE invoices_id_seq
+CREATE SEQUENCE public.invoices_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1336,14 +1350,14 @@ CREATE SEQUENCE invoices_id_seq
 -- Name: invoices_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE invoices_id_seq OWNED BY invoices.id;
+ALTER SEQUENCE public.invoices_id_seq OWNED BY public.invoices.id;
 
 
 --
 -- Name: job_configs; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE job_configs (
+CREATE TABLE public.job_configs (
     id integer NOT NULL,
     repository_id integer NOT NULL,
     key character varying NOT NULL,
@@ -1355,10 +1369,10 @@ CREATE TABLE job_configs (
 -- Name: job_configs_gpu; Type: MATERIALIZED VIEW; Schema: public; Owner: -
 --
 
-CREATE MATERIALIZED VIEW job_configs_gpu AS
+CREATE MATERIALIZED VIEW public.job_configs_gpu AS
  SELECT job_configs.id
-   FROM job_configs
-  WHERE (is_json((job_configs.config ->> 'resources'::text)) AND ((((job_configs.config ->> 'resources'::text))::jsonb ->> 'gpu'::text) IS NOT NULL))
+   FROM public.job_configs
+  WHERE (public.is_json((job_configs.config ->> 'resources'::text)) AND ((((job_configs.config ->> 'resources'::text))::jsonb ->> 'gpu'::text) IS NOT NULL))
   WITH NO DATA;
 
 
@@ -1366,7 +1380,7 @@ CREATE MATERIALIZED VIEW job_configs_gpu AS
 -- Name: job_configs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE job_configs_id_seq
+CREATE SEQUENCE public.job_configs_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1378,14 +1392,14 @@ CREATE SEQUENCE job_configs_id_seq
 -- Name: job_configs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE job_configs_id_seq OWNED BY job_configs.id;
+ALTER SEQUENCE public.job_configs_id_seq OWNED BY public.job_configs.id;
 
 
 --
 -- Name: job_versions; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE job_versions (
+CREATE TABLE public.job_versions (
     id integer NOT NULL,
     job_id integer,
     number integer,
@@ -1403,7 +1417,7 @@ CREATE TABLE job_versions (
 -- Name: job_versions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE job_versions_id_seq
+CREATE SEQUENCE public.job_versions_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1415,15 +1429,15 @@ CREATE SEQUENCE job_versions_id_seq
 -- Name: job_versions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE job_versions_id_seq OWNED BY job_versions.id;
+ALTER SEQUENCE public.job_versions_id_seq OWNED BY public.job_versions.id;
 
 
 --
 -- Name: jobs; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE jobs (
-    id bigint DEFAULT nextval('shared_builds_tasks_seq'::regclass) NOT NULL,
+CREATE TABLE public.jobs (
+    id bigint DEFAULT nextval('public.shared_builds_tasks_seq'::regclass) NOT NULL,
     repository_id integer,
     commit_id integer,
     source_type character varying,
@@ -1461,7 +1475,7 @@ CREATE TABLE jobs (
 -- Name: jobs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE jobs_id_seq
+CREATE SEQUENCE public.jobs_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1473,14 +1487,14 @@ CREATE SEQUENCE jobs_id_seq
 -- Name: jobs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE jobs_id_seq OWNED BY jobs.id;
+ALTER SEQUENCE public.jobs_id_seq OWNED BY public.jobs.id;
 
 
 --
 -- Name: memberships; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE memberships (
+CREATE TABLE public.memberships (
     id integer NOT NULL,
     organization_id integer,
     user_id integer,
@@ -1492,7 +1506,7 @@ CREATE TABLE memberships (
 -- Name: memberships_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE memberships_id_seq
+CREATE SEQUENCE public.memberships_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1504,14 +1518,14 @@ CREATE SEQUENCE memberships_id_seq
 -- Name: memberships_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE memberships_id_seq OWNED BY memberships.id;
+ALTER SEQUENCE public.memberships_id_seq OWNED BY public.memberships.id;
 
 
 --
 -- Name: messages; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE messages (
+CREATE TABLE public.messages (
     id integer NOT NULL,
     subject_id integer,
     subject_type character varying,
@@ -1528,7 +1542,7 @@ CREATE TABLE messages (
 -- Name: messages_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE messages_id_seq
+CREATE SEQUENCE public.messages_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1540,14 +1554,14 @@ CREATE SEQUENCE messages_id_seq
 -- Name: messages_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE messages_id_seq OWNED BY messages.id;
+ALTER SEQUENCE public.messages_id_seq OWNED BY public.messages.id;
 
 
 --
 -- Name: organizations; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE organizations (
+CREATE TABLE public.organizations (
     id integer NOT NULL,
     name character varying,
     login character varying,
@@ -1573,7 +1587,7 @@ CREATE TABLE organizations (
 -- Name: organizations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE organizations_id_seq
+CREATE SEQUENCE public.organizations_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1585,14 +1599,14 @@ CREATE SEQUENCE organizations_id_seq
 -- Name: organizations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE organizations_id_seq OWNED BY organizations.id;
+ALTER SEQUENCE public.organizations_id_seq OWNED BY public.organizations.id;
 
 
 --
 -- Name: owner_groups; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE owner_groups (
+CREATE TABLE public.owner_groups (
     id integer NOT NULL,
     uuid character varying,
     owner_type character varying,
@@ -1606,7 +1620,7 @@ CREATE TABLE owner_groups (
 -- Name: owner_groups_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE owner_groups_id_seq
+CREATE SEQUENCE public.owner_groups_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1618,14 +1632,14 @@ CREATE SEQUENCE owner_groups_id_seq
 -- Name: owner_groups_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE owner_groups_id_seq OWNED BY owner_groups.id;
+ALTER SEQUENCE public.owner_groups_id_seq OWNED BY public.owner_groups.id;
 
 
 --
 -- Name: permissions; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE permissions (
+CREATE TABLE public.permissions (
     id integer NOT NULL,
     user_id integer,
     repository_id integer,
@@ -1641,7 +1655,7 @@ CREATE TABLE permissions (
 -- Name: permissions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE permissions_id_seq
+CREATE SEQUENCE public.permissions_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1653,14 +1667,14 @@ CREATE SEQUENCE permissions_id_seq
 -- Name: permissions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE permissions_id_seq OWNED BY permissions.id;
+ALTER SEQUENCE public.permissions_id_seq OWNED BY public.permissions.id;
 
 
 --
 -- Name: pull_requests; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE pull_requests (
+CREATE TABLE public.pull_requests (
     id integer NOT NULL,
     repository_id integer,
     number integer,
@@ -1680,7 +1694,7 @@ CREATE TABLE pull_requests (
 -- Name: pull_requests_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE pull_requests_id_seq
+CREATE SEQUENCE public.pull_requests_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1692,14 +1706,14 @@ CREATE SEQUENCE pull_requests_id_seq
 -- Name: pull_requests_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE pull_requests_id_seq OWNED BY pull_requests.id;
+ALTER SEQUENCE public.pull_requests_id_seq OWNED BY public.pull_requests.id;
 
 
 --
 -- Name: queueable_jobs; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE queueable_jobs (
+CREATE TABLE public.queueable_jobs (
     id integer NOT NULL,
     job_id integer
 );
@@ -1709,7 +1723,7 @@ CREATE TABLE queueable_jobs (
 -- Name: queueable_jobs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE queueable_jobs_id_seq
+CREATE SEQUENCE public.queueable_jobs_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1721,14 +1735,14 @@ CREATE SEQUENCE queueable_jobs_id_seq
 -- Name: queueable_jobs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE queueable_jobs_id_seq OWNED BY queueable_jobs.id;
+ALTER SEQUENCE public.queueable_jobs_id_seq OWNED BY public.queueable_jobs.id;
 
 
 --
 -- Name: repo_counts; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE repo_counts (
+CREATE TABLE public.repo_counts (
     repository_id integer NOT NULL,
     requests integer,
     commits integer,
@@ -1746,7 +1760,7 @@ CREATE TABLE repo_counts (
 -- Name: repositories; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE repositories (
+CREATE TABLE public.repositories (
     id integer NOT NULL,
     name character varying,
     url character varying,
@@ -1786,7 +1800,7 @@ CREATE TABLE repositories (
 -- Name: repositories_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE repositories_id_seq
+CREATE SEQUENCE public.repositories_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1798,14 +1812,14 @@ CREATE SEQUENCE repositories_id_seq
 -- Name: repositories_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE repositories_id_seq OWNED BY repositories.id;
+ALTER SEQUENCE public.repositories_id_seq OWNED BY public.repositories.id;
 
 
 --
 -- Name: request_configs; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE request_configs (
+CREATE TABLE public.request_configs (
     id integer NOT NULL,
     repository_id integer NOT NULL,
     key character varying NOT NULL,
@@ -1817,7 +1831,7 @@ CREATE TABLE request_configs (
 -- Name: request_configs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE request_configs_id_seq
+CREATE SEQUENCE public.request_configs_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1829,14 +1843,14 @@ CREATE SEQUENCE request_configs_id_seq
 -- Name: request_configs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE request_configs_id_seq OWNED BY request_configs.id;
+ALTER SEQUENCE public.request_configs_id_seq OWNED BY public.request_configs.id;
 
 
 --
 -- Name: request_payloads; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE request_payloads (
+CREATE TABLE public.request_payloads (
     id integer NOT NULL,
     request_id integer NOT NULL,
     payload text,
@@ -1849,7 +1863,7 @@ CREATE TABLE request_payloads (
 -- Name: request_payloads_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE request_payloads_id_seq
+CREATE SEQUENCE public.request_payloads_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1861,14 +1875,14 @@ CREATE SEQUENCE request_payloads_id_seq
 -- Name: request_payloads_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE request_payloads_id_seq OWNED BY request_payloads.id;
+ALTER SEQUENCE public.request_payloads_id_seq OWNED BY public.request_payloads.id;
 
 
 --
 -- Name: request_raw_configs; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE request_raw_configs (
+CREATE TABLE public.request_raw_configs (
     id integer NOT NULL,
     config text,
     repository_id integer,
@@ -1880,7 +1894,7 @@ CREATE TABLE request_raw_configs (
 -- Name: request_raw_configs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE request_raw_configs_id_seq
+CREATE SEQUENCE public.request_raw_configs_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1892,14 +1906,14 @@ CREATE SEQUENCE request_raw_configs_id_seq
 -- Name: request_raw_configs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE request_raw_configs_id_seq OWNED BY request_raw_configs.id;
+ALTER SEQUENCE public.request_raw_configs_id_seq OWNED BY public.request_raw_configs.id;
 
 
 --
 -- Name: request_raw_configurations; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE request_raw_configurations (
+CREATE TABLE public.request_raw_configurations (
     id integer NOT NULL,
     request_id integer,
     request_raw_config_id integer,
@@ -1911,7 +1925,7 @@ CREATE TABLE request_raw_configurations (
 -- Name: request_raw_configurations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE request_raw_configurations_id_seq
+CREATE SEQUENCE public.request_raw_configurations_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1923,14 +1937,14 @@ CREATE SEQUENCE request_raw_configurations_id_seq
 -- Name: request_raw_configurations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE request_raw_configurations_id_seq OWNED BY request_raw_configurations.id;
+ALTER SEQUENCE public.request_raw_configurations_id_seq OWNED BY public.request_raw_configurations.id;
 
 
 --
 -- Name: request_yaml_configs; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE request_yaml_configs (
+CREATE TABLE public.request_yaml_configs (
     id integer NOT NULL,
     yaml text,
     repository_id integer,
@@ -1942,7 +1956,7 @@ CREATE TABLE request_yaml_configs (
 -- Name: request_yaml_configs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE request_yaml_configs_id_seq
+CREATE SEQUENCE public.request_yaml_configs_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1954,14 +1968,14 @@ CREATE SEQUENCE request_yaml_configs_id_seq
 -- Name: request_yaml_configs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE request_yaml_configs_id_seq OWNED BY request_yaml_configs.id;
+ALTER SEQUENCE public.request_yaml_configs_id_seq OWNED BY public.request_yaml_configs.id;
 
 
 --
 -- Name: requests; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE requests (
+CREATE TABLE public.requests (
     id integer NOT NULL,
     repository_id integer,
     commit_id integer,
@@ -1998,7 +2012,7 @@ CREATE TABLE requests (
 -- Name: requests_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE requests_id_seq
+CREATE SEQUENCE public.requests_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2010,14 +2024,14 @@ CREATE SEQUENCE requests_id_seq
 -- Name: requests_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE requests_id_seq OWNED BY requests.id;
+ALTER SEQUENCE public.requests_id_seq OWNED BY public.requests.id;
 
 
 --
 -- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE schema_migrations (
+CREATE TABLE public.schema_migrations (
     version character varying NOT NULL
 );
 
@@ -2026,7 +2040,7 @@ CREATE TABLE schema_migrations (
 -- Name: ssl_keys; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE ssl_keys (
+CREATE TABLE public.ssl_keys (
     id integer NOT NULL,
     repository_id integer,
     public_key text,
@@ -2042,7 +2056,7 @@ CREATE TABLE ssl_keys (
 -- Name: ssl_keys_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE ssl_keys_id_seq
+CREATE SEQUENCE public.ssl_keys_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2054,14 +2068,14 @@ CREATE SEQUENCE ssl_keys_id_seq
 -- Name: ssl_keys_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE ssl_keys_id_seq OWNED BY ssl_keys.id;
+ALTER SEQUENCE public.ssl_keys_id_seq OWNED BY public.ssl_keys.id;
 
 
 --
 -- Name: stages; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE stages (
+CREATE TABLE public.stages (
     id integer NOT NULL,
     build_id integer,
     number integer,
@@ -2078,7 +2092,7 @@ CREATE TABLE stages (
 -- Name: stages_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE stages_id_seq
+CREATE SEQUENCE public.stages_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2090,14 +2104,14 @@ CREATE SEQUENCE stages_id_seq
 -- Name: stages_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE stages_id_seq OWNED BY stages.id;
+ALTER SEQUENCE public.stages_id_seq OWNED BY public.stages.id;
 
 
 --
 -- Name: stars; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE stars (
+CREATE TABLE public.stars (
     id integer NOT NULL,
     repository_id integer,
     user_id integer,
@@ -2110,7 +2124,7 @@ CREATE TABLE stars (
 -- Name: stars_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE stars_id_seq
+CREATE SEQUENCE public.stars_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2122,14 +2136,14 @@ CREATE SEQUENCE stars_id_seq
 -- Name: stars_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE stars_id_seq OWNED BY stars.id;
+ALTER SEQUENCE public.stars_id_seq OWNED BY public.stars.id;
 
 
 --
 -- Name: stripe_events; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE stripe_events (
+CREATE TABLE public.stripe_events (
     id integer NOT NULL,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
@@ -2144,7 +2158,7 @@ CREATE TABLE stripe_events (
 -- Name: stripe_events_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE stripe_events_id_seq
+CREATE SEQUENCE public.stripe_events_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2156,14 +2170,14 @@ CREATE SEQUENCE stripe_events_id_seq
 -- Name: stripe_events_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE stripe_events_id_seq OWNED BY stripe_events.id;
+ALTER SEQUENCE public.stripe_events_id_seq OWNED BY public.stripe_events.id;
 
 
 --
 -- Name: subscriptions; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE subscriptions (
+CREATE TABLE public.subscriptions (
     id integer NOT NULL,
     cc_token character varying,
     valid_to timestamp without time zone,
@@ -2192,7 +2206,7 @@ CREATE TABLE subscriptions (
     canceled_at timestamp without time zone,
     canceled_by_id integer,
     status character varying,
-    source source_type DEFAULT 'unknown'::source_type NOT NULL,
+    source public.source_type DEFAULT 'unknown'::public.source_type NOT NULL,
     concurrency integer
 );
 
@@ -2201,7 +2215,7 @@ CREATE TABLE subscriptions (
 -- Name: subscriptions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE subscriptions_id_seq
+CREATE SEQUENCE public.subscriptions_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2213,14 +2227,14 @@ CREATE SEQUENCE subscriptions_id_seq
 -- Name: subscriptions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE subscriptions_id_seq OWNED BY subscriptions.id;
+ALTER SEQUENCE public.subscriptions_id_seq OWNED BY public.subscriptions.id;
 
 
 --
 -- Name: tags; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE tags (
+CREATE TABLE public.tags (
     id integer NOT NULL,
     repository_id integer,
     name character varying,
@@ -2237,7 +2251,7 @@ CREATE TABLE tags (
 -- Name: tags_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE tags_id_seq
+CREATE SEQUENCE public.tags_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2249,14 +2263,14 @@ CREATE SEQUENCE tags_id_seq
 -- Name: tags_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE tags_id_seq OWNED BY tags.id;
+ALTER SEQUENCE public.tags_id_seq OWNED BY public.tags.id;
 
 
 --
 -- Name: tokens; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE tokens (
+CREATE TABLE public.tokens (
     id integer NOT NULL,
     user_id integer,
     token character varying,
@@ -2269,7 +2283,7 @@ CREATE TABLE tokens (
 -- Name: tokens_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE tokens_id_seq
+CREATE SEQUENCE public.tokens_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2281,14 +2295,14 @@ CREATE SEQUENCE tokens_id_seq
 -- Name: tokens_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE tokens_id_seq OWNED BY tokens.id;
+ALTER SEQUENCE public.tokens_id_seq OWNED BY public.tokens.id;
 
 
 --
 -- Name: trial_allowances; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE trial_allowances (
+CREATE TABLE public.trial_allowances (
     id integer NOT NULL,
     trial_id integer,
     creator_id integer,
@@ -2304,7 +2318,7 @@ CREATE TABLE trial_allowances (
 -- Name: trial_allowances_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE trial_allowances_id_seq
+CREATE SEQUENCE public.trial_allowances_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2316,14 +2330,14 @@ CREATE SEQUENCE trial_allowances_id_seq
 -- Name: trial_allowances_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE trial_allowances_id_seq OWNED BY trial_allowances.id;
+ALTER SEQUENCE public.trial_allowances_id_seq OWNED BY public.trial_allowances.id;
 
 
 --
 -- Name: trials; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE trials (
+CREATE TABLE public.trials (
     id integer NOT NULL,
     owner_type character varying,
     owner_id integer,
@@ -2338,7 +2352,7 @@ CREATE TABLE trials (
 -- Name: trials_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE trials_id_seq
+CREATE SEQUENCE public.trials_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2350,14 +2364,14 @@ CREATE SEQUENCE trials_id_seq
 -- Name: trials_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE trials_id_seq OWNED BY trials.id;
+ALTER SEQUENCE public.trials_id_seq OWNED BY public.trials.id;
 
 
 --
 -- Name: urls; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE urls (
+CREATE TABLE public.urls (
     id integer NOT NULL,
     url character varying,
     code character varying,
@@ -2370,7 +2384,7 @@ CREATE TABLE urls (
 -- Name: urls_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE urls_id_seq
+CREATE SEQUENCE public.urls_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2382,14 +2396,14 @@ CREATE SEQUENCE urls_id_seq
 -- Name: urls_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE urls_id_seq OWNED BY urls.id;
+ALTER SEQUENCE public.urls_id_seq OWNED BY public.urls.id;
 
 
 --
 -- Name: user_beta_features; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE user_beta_features (
+CREATE TABLE public.user_beta_features (
     id integer NOT NULL,
     user_id integer,
     beta_feature_id integer,
@@ -2403,7 +2417,7 @@ CREATE TABLE user_beta_features (
 -- Name: user_beta_features_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE user_beta_features_id_seq
+CREATE SEQUENCE public.user_beta_features_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2415,14 +2429,14 @@ CREATE SEQUENCE user_beta_features_id_seq
 -- Name: user_beta_features_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE user_beta_features_id_seq OWNED BY user_beta_features.id;
+ALTER SEQUENCE public.user_beta_features_id_seq OWNED BY public.user_beta_features.id;
 
 
 --
 -- Name: users; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE users (
+CREATE TABLE public.users (
     id integer NOT NULL,
     name character varying,
     login character varying,
@@ -2455,7 +2469,7 @@ CREATE TABLE users (
 -- Name: users_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE users_id_seq
+CREATE SEQUENCE public.users_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2467,315 +2481,315 @@ CREATE SEQUENCE users_id_seq
 -- Name: users_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE users_id_seq OWNED BY users.id;
+ALTER SEQUENCE public.users_id_seq OWNED BY public.users.id;
 
 
 --
 -- Name: abuses id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY abuses ALTER COLUMN id SET DEFAULT nextval('abuses_id_seq'::regclass);
+ALTER TABLE ONLY public.abuses ALTER COLUMN id SET DEFAULT nextval('public.abuses_id_seq'::regclass);
 
 
 --
 -- Name: beta_features id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY beta_features ALTER COLUMN id SET DEFAULT nextval('beta_features_id_seq'::regclass);
+ALTER TABLE ONLY public.beta_features ALTER COLUMN id SET DEFAULT nextval('public.beta_features_id_seq'::regclass);
 
 
 --
 -- Name: beta_migration_requests id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY beta_migration_requests ALTER COLUMN id SET DEFAULT nextval('beta_migration_requests_id_seq'::regclass);
+ALTER TABLE ONLY public.beta_migration_requests ALTER COLUMN id SET DEFAULT nextval('public.beta_migration_requests_id_seq'::regclass);
 
 
 --
 -- Name: branches id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY branches ALTER COLUMN id SET DEFAULT nextval('branches_id_seq'::regclass);
+ALTER TABLE ONLY public.branches ALTER COLUMN id SET DEFAULT nextval('public.branches_id_seq'::regclass);
 
 
 --
 -- Name: broadcasts id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY broadcasts ALTER COLUMN id SET DEFAULT nextval('broadcasts_id_seq'::regclass);
+ALTER TABLE ONLY public.broadcasts ALTER COLUMN id SET DEFAULT nextval('public.broadcasts_id_seq'::regclass);
 
 
 --
 -- Name: build_configs id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY build_configs ALTER COLUMN id SET DEFAULT nextval('build_configs_id_seq'::regclass);
+ALTER TABLE ONLY public.build_configs ALTER COLUMN id SET DEFAULT nextval('public.build_configs_id_seq'::regclass);
 
 
 --
 -- Name: cancellations id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY cancellations ALTER COLUMN id SET DEFAULT nextval('cancellations_id_seq'::regclass);
+ALTER TABLE ONLY public.cancellations ALTER COLUMN id SET DEFAULT nextval('public.cancellations_id_seq'::regclass);
 
 
 --
 -- Name: commits id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY commits ALTER COLUMN id SET DEFAULT nextval('commits_id_seq'::regclass);
+ALTER TABLE ONLY public.commits ALTER COLUMN id SET DEFAULT nextval('public.commits_id_seq'::regclass);
 
 
 --
 -- Name: coupons id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY coupons ALTER COLUMN id SET DEFAULT nextval('coupons_id_seq'::regclass);
+ALTER TABLE ONLY public.coupons ALTER COLUMN id SET DEFAULT nextval('public.coupons_id_seq'::regclass);
 
 
 --
 -- Name: crons id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY crons ALTER COLUMN id SET DEFAULT nextval('crons_id_seq'::regclass);
+ALTER TABLE ONLY public.crons ALTER COLUMN id SET DEFAULT nextval('public.crons_id_seq'::regclass);
 
 
 --
 -- Name: email_unsubscribes id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY email_unsubscribes ALTER COLUMN id SET DEFAULT nextval('email_unsubscribes_id_seq'::regclass);
+ALTER TABLE ONLY public.email_unsubscribes ALTER COLUMN id SET DEFAULT nextval('public.email_unsubscribes_id_seq'::regclass);
 
 
 --
 -- Name: emails id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY emails ALTER COLUMN id SET DEFAULT nextval('emails_id_seq'::regclass);
+ALTER TABLE ONLY public.emails ALTER COLUMN id SET DEFAULT nextval('public.emails_id_seq'::regclass);
 
 
 --
 -- Name: gatekeeper_workers id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY gatekeeper_workers ALTER COLUMN id SET DEFAULT nextval('gatekeeper_workers_id_seq'::regclass);
+ALTER TABLE ONLY public.gatekeeper_workers ALTER COLUMN id SET DEFAULT nextval('public.gatekeeper_workers_id_seq'::regclass);
 
 
 --
 -- Name: installations id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY installations ALTER COLUMN id SET DEFAULT nextval('installations_id_seq'::regclass);
+ALTER TABLE ONLY public.installations ALTER COLUMN id SET DEFAULT nextval('public.installations_id_seq'::regclass);
 
 
 --
 -- Name: invoices id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY invoices ALTER COLUMN id SET DEFAULT nextval('invoices_id_seq'::regclass);
+ALTER TABLE ONLY public.invoices ALTER COLUMN id SET DEFAULT nextval('public.invoices_id_seq'::regclass);
 
 
 --
 -- Name: job_configs id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY job_configs ALTER COLUMN id SET DEFAULT nextval('job_configs_id_seq'::regclass);
+ALTER TABLE ONLY public.job_configs ALTER COLUMN id SET DEFAULT nextval('public.job_configs_id_seq'::regclass);
 
 
 --
 -- Name: job_versions id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY job_versions ALTER COLUMN id SET DEFAULT nextval('job_versions_id_seq'::regclass);
+ALTER TABLE ONLY public.job_versions ALTER COLUMN id SET DEFAULT nextval('public.job_versions_id_seq'::regclass);
 
 
 --
 -- Name: memberships id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY memberships ALTER COLUMN id SET DEFAULT nextval('memberships_id_seq'::regclass);
+ALTER TABLE ONLY public.memberships ALTER COLUMN id SET DEFAULT nextval('public.memberships_id_seq'::regclass);
 
 
 --
 -- Name: messages id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY messages ALTER COLUMN id SET DEFAULT nextval('messages_id_seq'::regclass);
+ALTER TABLE ONLY public.messages ALTER COLUMN id SET DEFAULT nextval('public.messages_id_seq'::regclass);
 
 
 --
 -- Name: organizations id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY organizations ALTER COLUMN id SET DEFAULT nextval('organizations_id_seq'::regclass);
+ALTER TABLE ONLY public.organizations ALTER COLUMN id SET DEFAULT nextval('public.organizations_id_seq'::regclass);
 
 
 --
 -- Name: owner_groups id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY owner_groups ALTER COLUMN id SET DEFAULT nextval('owner_groups_id_seq'::regclass);
+ALTER TABLE ONLY public.owner_groups ALTER COLUMN id SET DEFAULT nextval('public.owner_groups_id_seq'::regclass);
 
 
 --
 -- Name: permissions id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY permissions ALTER COLUMN id SET DEFAULT nextval('permissions_id_seq'::regclass);
+ALTER TABLE ONLY public.permissions ALTER COLUMN id SET DEFAULT nextval('public.permissions_id_seq'::regclass);
 
 
 --
 -- Name: pull_requests id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY pull_requests ALTER COLUMN id SET DEFAULT nextval('pull_requests_id_seq'::regclass);
+ALTER TABLE ONLY public.pull_requests ALTER COLUMN id SET DEFAULT nextval('public.pull_requests_id_seq'::regclass);
 
 
 --
 -- Name: queueable_jobs id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY queueable_jobs ALTER COLUMN id SET DEFAULT nextval('queueable_jobs_id_seq'::regclass);
+ALTER TABLE ONLY public.queueable_jobs ALTER COLUMN id SET DEFAULT nextval('public.queueable_jobs_id_seq'::regclass);
 
 
 --
 -- Name: repositories id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY repositories ALTER COLUMN id SET DEFAULT nextval('repositories_id_seq'::regclass);
+ALTER TABLE ONLY public.repositories ALTER COLUMN id SET DEFAULT nextval('public.repositories_id_seq'::regclass);
 
 
 --
 -- Name: request_configs id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY request_configs ALTER COLUMN id SET DEFAULT nextval('request_configs_id_seq'::regclass);
+ALTER TABLE ONLY public.request_configs ALTER COLUMN id SET DEFAULT nextval('public.request_configs_id_seq'::regclass);
 
 
 --
 -- Name: request_payloads id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY request_payloads ALTER COLUMN id SET DEFAULT nextval('request_payloads_id_seq'::regclass);
+ALTER TABLE ONLY public.request_payloads ALTER COLUMN id SET DEFAULT nextval('public.request_payloads_id_seq'::regclass);
 
 
 --
 -- Name: request_raw_configs id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY request_raw_configs ALTER COLUMN id SET DEFAULT nextval('request_raw_configs_id_seq'::regclass);
+ALTER TABLE ONLY public.request_raw_configs ALTER COLUMN id SET DEFAULT nextval('public.request_raw_configs_id_seq'::regclass);
 
 
 --
 -- Name: request_raw_configurations id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY request_raw_configurations ALTER COLUMN id SET DEFAULT nextval('request_raw_configurations_id_seq'::regclass);
+ALTER TABLE ONLY public.request_raw_configurations ALTER COLUMN id SET DEFAULT nextval('public.request_raw_configurations_id_seq'::regclass);
 
 
 --
 -- Name: request_yaml_configs id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY request_yaml_configs ALTER COLUMN id SET DEFAULT nextval('request_yaml_configs_id_seq'::regclass);
+ALTER TABLE ONLY public.request_yaml_configs ALTER COLUMN id SET DEFAULT nextval('public.request_yaml_configs_id_seq'::regclass);
 
 
 --
 -- Name: requests id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY requests ALTER COLUMN id SET DEFAULT nextval('requests_id_seq'::regclass);
+ALTER TABLE ONLY public.requests ALTER COLUMN id SET DEFAULT nextval('public.requests_id_seq'::regclass);
 
 
 --
 -- Name: ssl_keys id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY ssl_keys ALTER COLUMN id SET DEFAULT nextval('ssl_keys_id_seq'::regclass);
+ALTER TABLE ONLY public.ssl_keys ALTER COLUMN id SET DEFAULT nextval('public.ssl_keys_id_seq'::regclass);
 
 
 --
 -- Name: stages id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY stages ALTER COLUMN id SET DEFAULT nextval('stages_id_seq'::regclass);
+ALTER TABLE ONLY public.stages ALTER COLUMN id SET DEFAULT nextval('public.stages_id_seq'::regclass);
 
 
 --
 -- Name: stars id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY stars ALTER COLUMN id SET DEFAULT nextval('stars_id_seq'::regclass);
+ALTER TABLE ONLY public.stars ALTER COLUMN id SET DEFAULT nextval('public.stars_id_seq'::regclass);
 
 
 --
 -- Name: stripe_events id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY stripe_events ALTER COLUMN id SET DEFAULT nextval('stripe_events_id_seq'::regclass);
+ALTER TABLE ONLY public.stripe_events ALTER COLUMN id SET DEFAULT nextval('public.stripe_events_id_seq'::regclass);
 
 
 --
 -- Name: subscriptions id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY subscriptions ALTER COLUMN id SET DEFAULT nextval('subscriptions_id_seq'::regclass);
+ALTER TABLE ONLY public.subscriptions ALTER COLUMN id SET DEFAULT nextval('public.subscriptions_id_seq'::regclass);
 
 
 --
 -- Name: tags id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY tags ALTER COLUMN id SET DEFAULT nextval('tags_id_seq'::regclass);
+ALTER TABLE ONLY public.tags ALTER COLUMN id SET DEFAULT nextval('public.tags_id_seq'::regclass);
 
 
 --
 -- Name: tokens id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY tokens ALTER COLUMN id SET DEFAULT nextval('tokens_id_seq'::regclass);
+ALTER TABLE ONLY public.tokens ALTER COLUMN id SET DEFAULT nextval('public.tokens_id_seq'::regclass);
 
 
 --
 -- Name: trial_allowances id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY trial_allowances ALTER COLUMN id SET DEFAULT nextval('trial_allowances_id_seq'::regclass);
+ALTER TABLE ONLY public.trial_allowances ALTER COLUMN id SET DEFAULT nextval('public.trial_allowances_id_seq'::regclass);
 
 
 --
 -- Name: trials id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY trials ALTER COLUMN id SET DEFAULT nextval('trials_id_seq'::regclass);
+ALTER TABLE ONLY public.trials ALTER COLUMN id SET DEFAULT nextval('public.trials_id_seq'::regclass);
 
 
 --
 -- Name: urls id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY urls ALTER COLUMN id SET DEFAULT nextval('urls_id_seq'::regclass);
+ALTER TABLE ONLY public.urls ALTER COLUMN id SET DEFAULT nextval('public.urls_id_seq'::regclass);
 
 
 --
 -- Name: user_beta_features id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY user_beta_features ALTER COLUMN id SET DEFAULT nextval('user_beta_features_id_seq'::regclass);
+ALTER TABLE ONLY public.user_beta_features ALTER COLUMN id SET DEFAULT nextval('public.user_beta_features_id_seq'::regclass);
 
 
 --
 -- Name: users id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY users ALTER COLUMN id SET DEFAULT nextval('users_id_seq'::regclass);
+ALTER TABLE ONLY public.users ALTER COLUMN id SET DEFAULT nextval('public.users_id_seq'::regclass);
 
 
 --
 -- Name: abuses abuses_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY abuses
+ALTER TABLE ONLY public.abuses
     ADD CONSTRAINT abuses_pkey PRIMARY KEY (id);
 
 
@@ -2783,7 +2797,7 @@ ALTER TABLE ONLY abuses
 -- Name: ar_internal_metadata ar_internal_metadata_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY ar_internal_metadata
+ALTER TABLE ONLY public.ar_internal_metadata
     ADD CONSTRAINT ar_internal_metadata_pkey PRIMARY KEY (key);
 
 
@@ -2791,7 +2805,7 @@ ALTER TABLE ONLY ar_internal_metadata
 -- Name: beta_features beta_features_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY beta_features
+ALTER TABLE ONLY public.beta_features
     ADD CONSTRAINT beta_features_pkey PRIMARY KEY (id);
 
 
@@ -2799,7 +2813,7 @@ ALTER TABLE ONLY beta_features
 -- Name: beta_migration_requests beta_migration_requests_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY beta_migration_requests
+ALTER TABLE ONLY public.beta_migration_requests
     ADD CONSTRAINT beta_migration_requests_pkey PRIMARY KEY (id);
 
 
@@ -2807,7 +2821,7 @@ ALTER TABLE ONLY beta_migration_requests
 -- Name: branches branches_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY branches
+ALTER TABLE ONLY public.branches
     ADD CONSTRAINT branches_pkey PRIMARY KEY (id);
 
 
@@ -2815,7 +2829,7 @@ ALTER TABLE ONLY branches
 -- Name: broadcasts broadcasts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY broadcasts
+ALTER TABLE ONLY public.broadcasts
     ADD CONSTRAINT broadcasts_pkey PRIMARY KEY (id);
 
 
@@ -2823,7 +2837,7 @@ ALTER TABLE ONLY broadcasts
 -- Name: build_configs build_configs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY build_configs
+ALTER TABLE ONLY public.build_configs
     ADD CONSTRAINT build_configs_pkey PRIMARY KEY (id);
 
 
@@ -2831,7 +2845,7 @@ ALTER TABLE ONLY build_configs
 -- Name: builds builds_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY builds
+ALTER TABLE ONLY public.builds
     ADD CONSTRAINT builds_pkey PRIMARY KEY (id);
 
 
@@ -2839,7 +2853,7 @@ ALTER TABLE ONLY builds
 -- Name: cancellations cancellations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY cancellations
+ALTER TABLE ONLY public.cancellations
     ADD CONSTRAINT cancellations_pkey PRIMARY KEY (id);
 
 
@@ -2847,7 +2861,7 @@ ALTER TABLE ONLY cancellations
 -- Name: commits commits_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY commits
+ALTER TABLE ONLY public.commits
     ADD CONSTRAINT commits_pkey PRIMARY KEY (id);
 
 
@@ -2855,7 +2869,7 @@ ALTER TABLE ONLY commits
 -- Name: coupons coupons_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY coupons
+ALTER TABLE ONLY public.coupons
     ADD CONSTRAINT coupons_pkey PRIMARY KEY (id);
 
 
@@ -2863,7 +2877,7 @@ ALTER TABLE ONLY coupons
 -- Name: crons crons_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY crons
+ALTER TABLE ONLY public.crons
     ADD CONSTRAINT crons_pkey PRIMARY KEY (id);
 
 
@@ -2871,7 +2885,7 @@ ALTER TABLE ONLY crons
 -- Name: email_unsubscribes email_unsubscribes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY email_unsubscribes
+ALTER TABLE ONLY public.email_unsubscribes
     ADD CONSTRAINT email_unsubscribes_pkey PRIMARY KEY (id);
 
 
@@ -2879,7 +2893,7 @@ ALTER TABLE ONLY email_unsubscribes
 -- Name: emails emails_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY emails
+ALTER TABLE ONLY public.emails
     ADD CONSTRAINT emails_pkey PRIMARY KEY (id);
 
 
@@ -2887,7 +2901,7 @@ ALTER TABLE ONLY emails
 -- Name: gatekeeper_workers gatekeeper_workers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY gatekeeper_workers
+ALTER TABLE ONLY public.gatekeeper_workers
     ADD CONSTRAINT gatekeeper_workers_pkey PRIMARY KEY (id);
 
 
@@ -2895,7 +2909,7 @@ ALTER TABLE ONLY gatekeeper_workers
 -- Name: installations installations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY installations
+ALTER TABLE ONLY public.installations
     ADD CONSTRAINT installations_pkey PRIMARY KEY (id);
 
 
@@ -2903,7 +2917,7 @@ ALTER TABLE ONLY installations
 -- Name: invoices invoices_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY invoices
+ALTER TABLE ONLY public.invoices
     ADD CONSTRAINT invoices_pkey PRIMARY KEY (id);
 
 
@@ -2911,7 +2925,7 @@ ALTER TABLE ONLY invoices
 -- Name: job_configs job_configs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY job_configs
+ALTER TABLE ONLY public.job_configs
     ADD CONSTRAINT job_configs_pkey PRIMARY KEY (id);
 
 
@@ -2919,7 +2933,7 @@ ALTER TABLE ONLY job_configs
 -- Name: job_versions job_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY job_versions
+ALTER TABLE ONLY public.job_versions
     ADD CONSTRAINT job_versions_pkey PRIMARY KEY (id);
 
 
@@ -2927,7 +2941,7 @@ ALTER TABLE ONLY job_versions
 -- Name: jobs jobs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY jobs
+ALTER TABLE ONLY public.jobs
     ADD CONSTRAINT jobs_pkey PRIMARY KEY (id);
 
 
@@ -2935,7 +2949,7 @@ ALTER TABLE ONLY jobs
 -- Name: memberships memberships_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY memberships
+ALTER TABLE ONLY public.memberships
     ADD CONSTRAINT memberships_pkey PRIMARY KEY (id);
 
 
@@ -2943,7 +2957,7 @@ ALTER TABLE ONLY memberships
 -- Name: messages messages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY messages
+ALTER TABLE ONLY public.messages
     ADD CONSTRAINT messages_pkey PRIMARY KEY (id);
 
 
@@ -2951,7 +2965,7 @@ ALTER TABLE ONLY messages
 -- Name: organizations organizations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY organizations
+ALTER TABLE ONLY public.organizations
     ADD CONSTRAINT organizations_pkey PRIMARY KEY (id);
 
 
@@ -2959,7 +2973,7 @@ ALTER TABLE ONLY organizations
 -- Name: owner_groups owner_groups_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY owner_groups
+ALTER TABLE ONLY public.owner_groups
     ADD CONSTRAINT owner_groups_pkey PRIMARY KEY (id);
 
 
@@ -2967,7 +2981,7 @@ ALTER TABLE ONLY owner_groups
 -- Name: permissions permissions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY permissions
+ALTER TABLE ONLY public.permissions
     ADD CONSTRAINT permissions_pkey PRIMARY KEY (id);
 
 
@@ -2975,7 +2989,7 @@ ALTER TABLE ONLY permissions
 -- Name: pull_requests pull_requests_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY pull_requests
+ALTER TABLE ONLY public.pull_requests
     ADD CONSTRAINT pull_requests_pkey PRIMARY KEY (id);
 
 
@@ -2983,7 +2997,7 @@ ALTER TABLE ONLY pull_requests
 -- Name: queueable_jobs queueable_jobs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY queueable_jobs
+ALTER TABLE ONLY public.queueable_jobs
     ADD CONSTRAINT queueable_jobs_pkey PRIMARY KEY (id);
 
 
@@ -2991,7 +3005,7 @@ ALTER TABLE ONLY queueable_jobs
 -- Name: repositories repositories_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY repositories
+ALTER TABLE ONLY public.repositories
     ADD CONSTRAINT repositories_pkey PRIMARY KEY (id);
 
 
@@ -2999,7 +3013,7 @@ ALTER TABLE ONLY repositories
 -- Name: request_configs request_configs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY request_configs
+ALTER TABLE ONLY public.request_configs
     ADD CONSTRAINT request_configs_pkey PRIMARY KEY (id);
 
 
@@ -3007,7 +3021,7 @@ ALTER TABLE ONLY request_configs
 -- Name: request_payloads request_payloads_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY request_payloads
+ALTER TABLE ONLY public.request_payloads
     ADD CONSTRAINT request_payloads_pkey PRIMARY KEY (id);
 
 
@@ -3015,7 +3029,7 @@ ALTER TABLE ONLY request_payloads
 -- Name: request_raw_configs request_raw_configs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY request_raw_configs
+ALTER TABLE ONLY public.request_raw_configs
     ADD CONSTRAINT request_raw_configs_pkey PRIMARY KEY (id);
 
 
@@ -3023,7 +3037,7 @@ ALTER TABLE ONLY request_raw_configs
 -- Name: request_raw_configurations request_raw_configurations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY request_raw_configurations
+ALTER TABLE ONLY public.request_raw_configurations
     ADD CONSTRAINT request_raw_configurations_pkey PRIMARY KEY (id);
 
 
@@ -3031,7 +3045,7 @@ ALTER TABLE ONLY request_raw_configurations
 -- Name: request_yaml_configs request_yaml_configs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY request_yaml_configs
+ALTER TABLE ONLY public.request_yaml_configs
     ADD CONSTRAINT request_yaml_configs_pkey PRIMARY KEY (id);
 
 
@@ -3039,7 +3053,7 @@ ALTER TABLE ONLY request_yaml_configs
 -- Name: requests requests_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY requests
+ALTER TABLE ONLY public.requests
     ADD CONSTRAINT requests_pkey PRIMARY KEY (id);
 
 
@@ -3047,7 +3061,7 @@ ALTER TABLE ONLY requests
 -- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY schema_migrations
+ALTER TABLE ONLY public.schema_migrations
     ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
 
 
@@ -3055,7 +3069,7 @@ ALTER TABLE ONLY schema_migrations
 -- Name: ssl_keys ssl_keys_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY ssl_keys
+ALTER TABLE ONLY public.ssl_keys
     ADD CONSTRAINT ssl_keys_pkey PRIMARY KEY (id);
 
 
@@ -3063,7 +3077,7 @@ ALTER TABLE ONLY ssl_keys
 -- Name: stages stages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY stages
+ALTER TABLE ONLY public.stages
     ADD CONSTRAINT stages_pkey PRIMARY KEY (id);
 
 
@@ -3071,7 +3085,7 @@ ALTER TABLE ONLY stages
 -- Name: stars stars_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY stars
+ALTER TABLE ONLY public.stars
     ADD CONSTRAINT stars_pkey PRIMARY KEY (id);
 
 
@@ -3079,7 +3093,7 @@ ALTER TABLE ONLY stars
 -- Name: stripe_events stripe_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY stripe_events
+ALTER TABLE ONLY public.stripe_events
     ADD CONSTRAINT stripe_events_pkey PRIMARY KEY (id);
 
 
@@ -3087,7 +3101,7 @@ ALTER TABLE ONLY stripe_events
 -- Name: subscriptions subscriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY subscriptions
+ALTER TABLE ONLY public.subscriptions
     ADD CONSTRAINT subscriptions_pkey PRIMARY KEY (id);
 
 
@@ -3095,7 +3109,7 @@ ALTER TABLE ONLY subscriptions
 -- Name: tags tags_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY tags
+ALTER TABLE ONLY public.tags
     ADD CONSTRAINT tags_pkey PRIMARY KEY (id);
 
 
@@ -3103,7 +3117,7 @@ ALTER TABLE ONLY tags
 -- Name: tokens tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY tokens
+ALTER TABLE ONLY public.tokens
     ADD CONSTRAINT tokens_pkey PRIMARY KEY (id);
 
 
@@ -3111,7 +3125,7 @@ ALTER TABLE ONLY tokens
 -- Name: trial_allowances trial_allowances_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY trial_allowances
+ALTER TABLE ONLY public.trial_allowances
     ADD CONSTRAINT trial_allowances_pkey PRIMARY KEY (id);
 
 
@@ -3119,7 +3133,7 @@ ALTER TABLE ONLY trial_allowances
 -- Name: trials trials_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY trials
+ALTER TABLE ONLY public.trials
     ADD CONSTRAINT trials_pkey PRIMARY KEY (id);
 
 
@@ -3127,7 +3141,7 @@ ALTER TABLE ONLY trials
 -- Name: urls urls_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY urls
+ALTER TABLE ONLY public.urls
     ADD CONSTRAINT urls_pkey PRIMARY KEY (id);
 
 
@@ -3135,7 +3149,7 @@ ALTER TABLE ONLY urls
 -- Name: user_beta_features user_beta_features_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY user_beta_features
+ALTER TABLE ONLY public.user_beta_features
     ADD CONSTRAINT user_beta_features_pkey PRIMARY KEY (id);
 
 
@@ -3143,7 +3157,7 @@ ALTER TABLE ONLY user_beta_features
 -- Name: users users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY users
+ALTER TABLE ONLY public.users
     ADD CONSTRAINT users_pkey PRIMARY KEY (id);
 
 
@@ -3151,1496 +3165,1510 @@ ALTER TABLE ONLY users
 -- Name: github_id_installations_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX github_id_installations_idx ON installations USING btree (github_id);
+CREATE UNIQUE INDEX github_id_installations_idx ON public.installations USING btree (github_id);
 
 
 --
 -- Name: index_abuses_on_owner; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_abuses_on_owner ON abuses USING btree (owner_id);
+CREATE INDEX index_abuses_on_owner ON public.abuses USING btree (owner_id);
 
 
 --
 -- Name: index_abuses_on_owner_id_and_owner_type_and_level; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_abuses_on_owner_id_and_owner_type_and_level ON abuses USING btree (owner_id, owner_type, level);
+CREATE UNIQUE INDEX index_abuses_on_owner_id_and_owner_type_and_level ON public.abuses USING btree (owner_id, owner_type, level);
 
 
 --
 -- Name: index_active_on_org; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_active_on_org ON repositories USING btree (active_on_org);
+CREATE INDEX index_active_on_org ON public.repositories USING btree (active_on_org);
 
 
 --
 -- Name: index_beta_migration_requests_on_owner_type_and_owner_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_beta_migration_requests_on_owner_type_and_owner_id ON beta_migration_requests USING btree (owner_type, owner_id);
+CREATE INDEX index_beta_migration_requests_on_owner_type_and_owner_id ON public.beta_migration_requests USING btree (owner_type, owner_id);
 
 
 --
 -- Name: index_branches_on_com_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_branches_on_com_id ON branches USING btree (com_id);
+CREATE UNIQUE INDEX index_branches_on_com_id ON public.branches USING btree (com_id);
 
 
 --
 -- Name: index_branches_on_last_build_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_branches_on_last_build_id ON branches USING btree (last_build_id);
+CREATE INDEX index_branches_on_last_build_id ON public.branches USING btree (last_build_id);
 
 
 --
 -- Name: index_branches_on_org_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_branches_on_org_id ON branches USING btree (org_id);
+CREATE UNIQUE INDEX index_branches_on_org_id ON public.branches USING btree (org_id);
 
 
 --
 -- Name: index_branches_on_repository_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_branches_on_repository_id ON branches USING btree (repository_id);
+CREATE INDEX index_branches_on_repository_id ON public.branches USING btree (repository_id);
 
 
 --
 -- Name: index_branches_on_repository_id_and_name; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_branches_on_repository_id_and_name ON branches USING btree (repository_id, name);
+CREATE UNIQUE INDEX index_branches_on_repository_id_and_name ON public.branches USING btree (repository_id, name);
 
 
 --
 -- Name: index_branches_on_repository_id_and_name_and_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_branches_on_repository_id_and_name_and_id ON branches USING btree (repository_id, name, id);
+CREATE INDEX index_branches_on_repository_id_and_name_and_id ON public.branches USING btree (repository_id, name, id);
 
 
 --
 -- Name: index_branches_repository_id_unique_name; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_branches_repository_id_unique_name ON branches USING btree (repository_id, unique_name) WHERE (unique_name IS NOT NULL);
+CREATE UNIQUE INDEX index_branches_repository_id_unique_name ON public.branches USING btree (repository_id, unique_name) WHERE (unique_name IS NOT NULL);
 
 
 --
 -- Name: index_broadcasts_on_recipient_id_and_recipient_type; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_broadcasts_on_recipient_id_and_recipient_type ON broadcasts USING btree (recipient_id, recipient_type);
+CREATE INDEX index_broadcasts_on_recipient_id_and_recipient_type ON public.broadcasts USING btree (recipient_id, recipient_type);
 
 
 --
 -- Name: index_build_configs_on_repository_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_build_configs_on_repository_id ON build_configs USING btree (repository_id);
+CREATE INDEX index_build_configs_on_repository_id ON public.build_configs USING btree (repository_id);
 
 
 --
 -- Name: index_build_configs_on_repository_id_and_key; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_build_configs_on_repository_id_and_key ON build_configs USING btree (repository_id, key);
+CREATE INDEX index_build_configs_on_repository_id_and_key ON public.build_configs USING btree (repository_id, key);
 
 
 --
 -- Name: index_builds_on_branch_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_builds_on_branch_id ON builds USING btree (branch_id);
+CREATE INDEX index_builds_on_branch_id ON public.builds USING btree (branch_id);
 
 
 --
 -- Name: index_builds_on_com_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_builds_on_com_id ON builds USING btree (com_id);
+CREATE UNIQUE INDEX index_builds_on_com_id ON public.builds USING btree (com_id);
 
 
 --
 -- Name: index_builds_on_commit_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_builds_on_commit_id ON builds USING btree (commit_id);
+CREATE INDEX index_builds_on_commit_id ON public.builds USING btree (commit_id);
 
 
 --
 -- Name: index_builds_on_config_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_builds_on_config_id ON builds USING btree (config_id);
+CREATE INDEX index_builds_on_config_id ON public.builds USING btree (config_id);
 
 
 --
 -- Name: index_builds_on_created_at; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_builds_on_created_at ON builds USING btree (created_at);
+CREATE INDEX index_builds_on_created_at ON public.builds USING btree (created_at);
 
 
 --
 -- Name: index_builds_on_org_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_builds_on_org_id ON builds USING btree (org_id);
+CREATE UNIQUE INDEX index_builds_on_org_id ON public.builds USING btree (org_id);
 
 
 --
 -- Name: index_builds_on_pull_request_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_builds_on_pull_request_id ON builds USING btree (pull_request_id);
+CREATE INDEX index_builds_on_pull_request_id ON public.builds USING btree (pull_request_id);
 
 
 --
 -- Name: index_builds_on_repo_branch_event_type_and_private; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_builds_on_repo_branch_event_type_and_private ON builds USING btree (repository_id, branch, event_type, private);
+CREATE INDEX index_builds_on_repo_branch_event_type_and_private ON public.builds USING btree (repository_id, branch, event_type, private);
 
 
 --
 -- Name: index_builds_on_repository_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_builds_on_repository_id ON builds USING btree (repository_id);
+CREATE INDEX index_builds_on_repository_id ON public.builds USING btree (repository_id);
 
 
 --
 -- Name: index_builds_on_repository_id_and_branch_and_event_type; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_builds_on_repository_id_and_branch_and_event_type ON builds USING btree (repository_id, branch, event_type) WHERE ((state)::text = ANY ((ARRAY['created'::character varying, 'queued'::character varying, 'received'::character varying])::text[]));
+CREATE INDEX index_builds_on_repository_id_and_branch_and_event_type ON public.builds USING btree (repository_id, branch, event_type) WHERE ((state)::text = ANY ((ARRAY['created'::character varying, 'queued'::character varying, 'received'::character varying])::text[]));
 
 
 --
 -- Name: index_builds_on_repository_id_and_branch_and_event_type_and_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_builds_on_repository_id_and_branch_and_event_type_and_id ON builds USING btree (repository_id, branch, event_type, id);
+CREATE INDEX index_builds_on_repository_id_and_branch_and_event_type_and_id ON public.builds USING btree (repository_id, branch, event_type, id);
 
 
 --
 -- Name: index_builds_on_repository_id_and_branch_and_id_desc; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_builds_on_repository_id_and_branch_and_id_desc ON builds USING btree (repository_id, branch, id DESC);
+CREATE INDEX index_builds_on_repository_id_and_branch_and_id_desc ON public.builds USING btree (repository_id, branch, id DESC);
 
 
 --
 -- Name: index_builds_on_repository_id_and_number; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_builds_on_repository_id_and_number ON builds USING btree (repository_id, ((number)::integer));
+CREATE INDEX index_builds_on_repository_id_and_number ON public.builds USING btree (repository_id, ((number)::integer));
 
 
 --
 -- Name: index_builds_on_repository_id_and_number_and_event_type; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_builds_on_repository_id_and_number_and_event_type ON builds USING btree (repository_id, number, event_type);
+CREATE INDEX index_builds_on_repository_id_and_number_and_event_type ON public.builds USING btree (repository_id, number, event_type);
 
 
 --
 -- Name: index_builds_on_repository_id_event_type_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_builds_on_repository_id_event_type_id ON builds USING btree (repository_id, event_type, id DESC);
+CREATE INDEX index_builds_on_repository_id_event_type_id ON public.builds USING btree (repository_id, event_type, id DESC);
 
 
 --
 -- Name: index_builds_on_repository_id_where_state_not_finished; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_builds_on_repository_id_where_state_not_finished ON builds USING btree (repository_id) WHERE ((state)::text = ANY ((ARRAY['created'::character varying, 'queued'::character varying, 'received'::character varying, 'started'::character varying])::text[]));
+CREATE INDEX index_builds_on_repository_id_where_state_not_finished ON public.builds USING btree (repository_id) WHERE ((state)::text = ANY ((ARRAY['created'::character varying, 'queued'::character varying, 'received'::character varying, 'started'::character varying])::text[]));
 
 
 --
 -- Name: index_builds_on_request_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_builds_on_request_id ON builds USING btree (request_id);
+CREATE INDEX index_builds_on_request_id ON public.builds USING btree (request_id);
 
 
 --
 -- Name: index_builds_on_sender_type_and_sender_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_builds_on_sender_type_and_sender_id ON builds USING btree (sender_type, sender_id);
+CREATE INDEX index_builds_on_sender_type_and_sender_id ON public.builds USING btree (sender_type, sender_id);
 
 
 --
 -- Name: index_builds_on_state; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_builds_on_state ON builds USING btree (state);
+CREATE INDEX index_builds_on_state ON public.builds USING btree (state);
 
 
 --
 -- Name: index_builds_on_tag_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_builds_on_tag_id ON builds USING btree (tag_id);
+CREATE INDEX index_builds_on_tag_id ON public.builds USING btree (tag_id);
 
 
 --
 -- Name: index_builds_on_updated_at; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_builds_on_updated_at ON builds USING btree (updated_at);
+CREATE INDEX index_builds_on_updated_at ON public.builds USING btree (updated_at);
+
+
+--
+-- Name: index_builds_repository_id_unique_number; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_builds_repository_id_unique_number ON public.builds USING btree (repository_id, unique_number) WHERE (unique_number IS NOT NULL);
 
 
 --
 -- Name: index_cancellations_on_subscription_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_cancellations_on_subscription_id ON cancellations USING btree (subscription_id);
+CREATE INDEX index_cancellations_on_subscription_id ON public.cancellations USING btree (subscription_id);
 
 
 --
 -- Name: index_commits_on_author_email; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_commits_on_author_email ON commits USING btree (author_email);
+CREATE INDEX index_commits_on_author_email ON public.commits USING btree (author_email);
 
 
 --
 -- Name: index_commits_on_branch_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_commits_on_branch_id ON commits USING btree (branch_id);
+CREATE INDEX index_commits_on_branch_id ON public.commits USING btree (branch_id);
 
 
 --
 -- Name: index_commits_on_com_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_commits_on_com_id ON commits USING btree (com_id);
+CREATE UNIQUE INDEX index_commits_on_com_id ON public.commits USING btree (com_id);
 
 
 --
 -- Name: index_commits_on_committer_email; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_commits_on_committer_email ON commits USING btree (committer_email);
+CREATE INDEX index_commits_on_committer_email ON public.commits USING btree (committer_email);
 
 
 --
 -- Name: index_commits_on_org_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_commits_on_org_id ON commits USING btree (org_id);
+CREATE UNIQUE INDEX index_commits_on_org_id ON public.commits USING btree (org_id);
 
 
 --
 -- Name: index_commits_on_repository_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_commits_on_repository_id ON commits USING btree (repository_id);
+CREATE INDEX index_commits_on_repository_id ON public.commits USING btree (repository_id);
 
 
 --
 -- Name: index_commits_on_tag_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_commits_on_tag_id ON commits USING btree (tag_id);
+CREATE INDEX index_commits_on_tag_id ON public.commits USING btree (tag_id);
 
 
 --
 -- Name: index_crons_on_branch_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_crons_on_branch_id ON crons USING btree (branch_id);
+CREATE UNIQUE INDEX index_crons_on_branch_id ON public.crons USING btree (branch_id);
 
 
 --
 -- Name: index_crons_on_com_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_crons_on_com_id ON crons USING btree (com_id);
+CREATE UNIQUE INDEX index_crons_on_com_id ON public.crons USING btree (com_id);
 
 
 --
 -- Name: index_crons_on_next_run; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_crons_on_next_run ON crons USING btree (next_run) WHERE (active IS TRUE);
+CREATE INDEX index_crons_on_next_run ON public.crons USING btree (next_run) WHERE (active IS TRUE);
 
 
 --
 -- Name: index_crons_on_org_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_crons_on_org_id ON crons USING btree (org_id);
+CREATE UNIQUE INDEX index_crons_on_org_id ON public.crons USING btree (org_id);
 
 
 --
 -- Name: index_email_unsubscribes_on_repository_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_email_unsubscribes_on_repository_id ON email_unsubscribes USING btree (repository_id);
+CREATE INDEX index_email_unsubscribes_on_repository_id ON public.email_unsubscribes USING btree (repository_id);
 
 
 --
 -- Name: index_email_unsubscribes_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_email_unsubscribes_on_user_id ON email_unsubscribes USING btree (user_id);
+CREATE INDEX index_email_unsubscribes_on_user_id ON public.email_unsubscribes USING btree (user_id);
 
 
 --
 -- Name: index_email_unsubscribes_on_user_id_and_repository_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_email_unsubscribes_on_user_id_and_repository_id ON email_unsubscribes USING btree (user_id, repository_id);
+CREATE UNIQUE INDEX index_email_unsubscribes_on_user_id_and_repository_id ON public.email_unsubscribes USING btree (user_id, repository_id);
 
 
 --
 -- Name: index_emails_on_email; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_emails_on_email ON emails USING btree (email);
+CREATE INDEX index_emails_on_email ON public.emails USING btree (email);
 
 
 --
 -- Name: index_emails_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_emails_on_user_id ON emails USING btree (user_id);
+CREATE INDEX index_emails_on_user_id ON public.emails USING btree (user_id);
 
 
 --
 -- Name: index_installations_on_owner_type_and_owner_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_installations_on_owner_type_and_owner_id ON installations USING btree (owner_type, owner_id);
+CREATE INDEX index_installations_on_owner_type_and_owner_id ON public.installations USING btree (owner_type, owner_id);
 
 
 --
 -- Name: index_invoices_on_stripe_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_invoices_on_stripe_id ON invoices USING btree (stripe_id);
+CREATE INDEX index_invoices_on_stripe_id ON public.invoices USING btree (stripe_id);
 
 
 --
 -- Name: index_job_configs_on_config_resources_gpu; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_job_configs_on_config_resources_gpu ON job_configs USING btree (((((config ->> 'resources'::text))::jsonb ->> 'gpu'::text))) WHERE (is_json((config ->> 'resources'::text)) AND ((((config ->> 'resources'::text))::jsonb ->> 'gpu'::text) IS NOT NULL));
+CREATE INDEX index_job_configs_on_config_resources_gpu ON public.job_configs USING btree (((((config ->> 'resources'::text))::jsonb ->> 'gpu'::text))) WHERE (public.is_json((config ->> 'resources'::text)) AND ((((config ->> 'resources'::text))::jsonb ->> 'gpu'::text) IS NOT NULL));
 
 
 --
 -- Name: index_job_configs_on_repository_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_job_configs_on_repository_id ON job_configs USING btree (repository_id);
+CREATE INDEX index_job_configs_on_repository_id ON public.job_configs USING btree (repository_id);
 
 
 --
 -- Name: index_job_configs_on_repository_id_and_key; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_job_configs_on_repository_id_and_key ON job_configs USING btree (repository_id, key);
+CREATE INDEX index_job_configs_on_repository_id_and_key ON public.job_configs USING btree (repository_id, key);
 
 
 --
 -- Name: index_jobs_on_com_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_jobs_on_com_id ON jobs USING btree (com_id);
+CREATE UNIQUE INDEX index_jobs_on_com_id ON public.jobs USING btree (com_id);
 
 
 --
 -- Name: index_jobs_on_commit_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_jobs_on_commit_id ON jobs USING btree (commit_id);
+CREATE INDEX index_jobs_on_commit_id ON public.jobs USING btree (commit_id);
 
 
 --
 -- Name: index_jobs_on_config_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_jobs_on_config_id ON jobs USING btree (config_id);
+CREATE INDEX index_jobs_on_config_id ON public.jobs USING btree (config_id);
 
 
 --
 -- Name: index_jobs_on_created_at; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_jobs_on_created_at ON jobs USING btree (created_at);
+CREATE INDEX index_jobs_on_created_at ON public.jobs USING btree (created_at);
 
 
 --
 -- Name: index_jobs_on_org_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_jobs_on_org_id ON jobs USING btree (org_id);
+CREATE UNIQUE INDEX index_jobs_on_org_id ON public.jobs USING btree (org_id);
 
 
 --
 -- Name: index_jobs_on_owner_id_and_owner_type_and_state; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_jobs_on_owner_id_and_owner_type_and_state ON jobs USING btree (owner_id, owner_type, state);
+CREATE INDEX index_jobs_on_owner_id_and_owner_type_and_state ON public.jobs USING btree (owner_id, owner_type, state);
 
 
 --
 -- Name: index_jobs_on_owner_where_state_running; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_jobs_on_owner_where_state_running ON jobs USING btree (owner_id, owner_type) WHERE ((state)::text = ANY ((ARRAY['queued'::character varying, 'received'::character varying, 'started'::character varying])::text[]));
+CREATE INDEX index_jobs_on_owner_where_state_running ON public.jobs USING btree (owner_id, owner_type) WHERE ((state)::text = ANY ((ARRAY['queued'::character varying, 'received'::character varying, 'started'::character varying])::text[]));
 
 
 --
 -- Name: index_jobs_on_repository_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_jobs_on_repository_id ON jobs USING btree (repository_id);
+CREATE INDEX index_jobs_on_repository_id ON public.jobs USING btree (repository_id);
 
 
 --
 -- Name: index_jobs_on_repository_id_where_state_running; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_jobs_on_repository_id_where_state_running ON jobs USING btree (repository_id) WHERE ((state)::text = ANY ((ARRAY['queued'::character varying, 'received'::character varying, 'started'::character varying])::text[]));
+CREATE INDEX index_jobs_on_repository_id_where_state_running ON public.jobs USING btree (repository_id) WHERE ((state)::text = ANY ((ARRAY['queued'::character varying, 'received'::character varying, 'started'::character varying])::text[]));
 
 
 --
 -- Name: index_jobs_on_source_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_jobs_on_source_id ON jobs USING btree (source_id);
+CREATE INDEX index_jobs_on_source_id ON public.jobs USING btree (source_id);
 
 
 --
 -- Name: index_jobs_on_stage_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_jobs_on_stage_id ON jobs USING btree (stage_id);
+CREATE INDEX index_jobs_on_stage_id ON public.jobs USING btree (stage_id);
 
 
 --
 -- Name: index_jobs_on_state; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_jobs_on_state ON jobs USING btree (state);
+CREATE INDEX index_jobs_on_state ON public.jobs USING btree (state);
 
 
 --
 -- Name: index_jobs_on_type_and_source_id_and_source_type; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_jobs_on_type_and_source_id_and_source_type ON jobs USING btree (type, source_id, source_type);
+CREATE INDEX index_jobs_on_type_and_source_id_and_source_type ON public.jobs USING btree (type, source_id, source_type);
 
 
 --
 -- Name: index_jobs_on_updated_at; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_jobs_on_updated_at ON jobs USING btree (updated_at);
+CREATE INDEX index_jobs_on_updated_at ON public.jobs USING btree (updated_at);
 
 
 --
 -- Name: index_memberships_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_memberships_on_user_id ON memberships USING btree (user_id);
+CREATE INDEX index_memberships_on_user_id ON public.memberships USING btree (user_id);
 
 
 --
 -- Name: index_messages_on_subject_type_and_subject_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_messages_on_subject_type_and_subject_id ON messages USING btree (subject_type, subject_id);
+CREATE INDEX index_messages_on_subject_type_and_subject_id ON public.messages USING btree (subject_type, subject_id);
 
 
 --
 -- Name: index_organization_id_and_user_id_on_memberships; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_organization_id_and_user_id_on_memberships ON memberships USING btree (organization_id, user_id);
+CREATE UNIQUE INDEX index_organization_id_and_user_id_on_memberships ON public.memberships USING btree (organization_id, user_id);
 
 
 --
 -- Name: index_organizations_on_com_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_organizations_on_com_id ON organizations USING btree (com_id);
+CREATE UNIQUE INDEX index_organizations_on_com_id ON public.organizations USING btree (com_id);
 
 
 --
 -- Name: index_organizations_on_github_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_organizations_on_github_id ON organizations USING btree (github_id);
+CREATE UNIQUE INDEX index_organizations_on_github_id ON public.organizations USING btree (github_id);
 
 
 --
 -- Name: index_organizations_on_login; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_organizations_on_login ON organizations USING btree (login);
+CREATE INDEX index_organizations_on_login ON public.organizations USING btree (login);
 
 
 --
 -- Name: index_organizations_on_lower_login; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_organizations_on_lower_login ON organizations USING btree (lower((login)::text));
+CREATE INDEX index_organizations_on_lower_login ON public.organizations USING btree (lower((login)::text));
 
 
 --
 -- Name: index_organizations_on_org_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_organizations_on_org_id ON organizations USING btree (org_id);
+CREATE UNIQUE INDEX index_organizations_on_org_id ON public.organizations USING btree (org_id);
 
 
 --
 -- Name: index_organizations_on_updated_at; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_organizations_on_updated_at ON organizations USING btree (updated_at);
+CREATE INDEX index_organizations_on_updated_at ON public.organizations USING btree (updated_at);
 
 
 --
 -- Name: index_owner_groups_on_owner_type_and_owner_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_owner_groups_on_owner_type_and_owner_id ON owner_groups USING btree (owner_type, owner_id);
+CREATE INDEX index_owner_groups_on_owner_type_and_owner_id ON public.owner_groups USING btree (owner_type, owner_id);
 
 
 --
 -- Name: index_owner_groups_on_uuid; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_owner_groups_on_uuid ON owner_groups USING btree (uuid);
+CREATE INDEX index_owner_groups_on_uuid ON public.owner_groups USING btree (uuid);
 
 
 --
 -- Name: index_permissions_on_com_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_permissions_on_com_id ON permissions USING btree (com_id);
+CREATE UNIQUE INDEX index_permissions_on_com_id ON public.permissions USING btree (com_id);
 
 
 --
 -- Name: index_permissions_on_org_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_permissions_on_org_id ON permissions USING btree (org_id);
+CREATE UNIQUE INDEX index_permissions_on_org_id ON public.permissions USING btree (org_id);
 
 
 --
 -- Name: index_permissions_on_repository_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_permissions_on_repository_id ON permissions USING btree (repository_id);
+CREATE INDEX index_permissions_on_repository_id ON public.permissions USING btree (repository_id);
 
 
 --
 -- Name: index_permissions_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_permissions_on_user_id ON permissions USING btree (user_id);
+CREATE INDEX index_permissions_on_user_id ON public.permissions USING btree (user_id);
 
 
 --
 -- Name: index_permissions_on_user_id_and_repository_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_permissions_on_user_id_and_repository_id ON permissions USING btree (user_id, repository_id);
+CREATE UNIQUE INDEX index_permissions_on_user_id_and_repository_id ON public.permissions USING btree (user_id, repository_id);
 
 
 --
 -- Name: index_pull_requests_on_com_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_pull_requests_on_com_id ON pull_requests USING btree (com_id);
+CREATE UNIQUE INDEX index_pull_requests_on_com_id ON public.pull_requests USING btree (com_id);
 
 
 --
 -- Name: index_pull_requests_on_org_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_pull_requests_on_org_id ON pull_requests USING btree (org_id);
+CREATE UNIQUE INDEX index_pull_requests_on_org_id ON public.pull_requests USING btree (org_id);
 
 
 --
 -- Name: index_pull_requests_on_repository_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_pull_requests_on_repository_id ON pull_requests USING btree (repository_id);
+CREATE INDEX index_pull_requests_on_repository_id ON public.pull_requests USING btree (repository_id);
 
 
 --
 -- Name: index_pull_requests_on_repository_id_and_number; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_pull_requests_on_repository_id_and_number ON pull_requests USING btree (repository_id, number);
+CREATE UNIQUE INDEX index_pull_requests_on_repository_id_and_number ON public.pull_requests USING btree (repository_id, number);
 
 
 --
 -- Name: index_queueable_jobs_on_job_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_queueable_jobs_on_job_id ON queueable_jobs USING btree (job_id);
+CREATE INDEX index_queueable_jobs_on_job_id ON public.queueable_jobs USING btree (job_id);
 
 
 --
 -- Name: index_repo_counts_on_repository_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_repo_counts_on_repository_id ON repo_counts USING btree (repository_id);
+CREATE INDEX index_repo_counts_on_repository_id ON public.repo_counts USING btree (repository_id);
 
 
 --
 -- Name: index_repositories_on_active; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_repositories_on_active ON repositories USING btree (active);
+CREATE INDEX index_repositories_on_active ON public.repositories USING btree (active);
 
 
 --
 -- Name: index_repositories_on_com_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_repositories_on_com_id ON repositories USING btree (com_id);
+CREATE UNIQUE INDEX index_repositories_on_com_id ON public.repositories USING btree (com_id);
 
 
 --
 -- Name: index_repositories_on_current_build_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_repositories_on_current_build_id ON repositories USING btree (current_build_id);
+CREATE INDEX index_repositories_on_current_build_id ON public.repositories USING btree (current_build_id);
 
 
 --
 -- Name: index_repositories_on_github_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_repositories_on_github_id ON repositories USING btree (github_id);
+CREATE UNIQUE INDEX index_repositories_on_github_id ON public.repositories USING btree (github_id);
 
 
 --
 -- Name: index_repositories_on_last_build_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_repositories_on_last_build_id ON repositories USING btree (last_build_id);
+CREATE INDEX index_repositories_on_last_build_id ON public.repositories USING btree (last_build_id);
 
 
 --
 -- Name: index_repositories_on_lower_name; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_repositories_on_lower_name ON repositories USING btree (lower((name)::text));
+CREATE INDEX index_repositories_on_lower_name ON public.repositories USING btree (lower((name)::text));
 
 
 --
 -- Name: index_repositories_on_name; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_repositories_on_name ON repositories USING btree (name);
+CREATE INDEX index_repositories_on_name ON public.repositories USING btree (name);
 
 
 --
 -- Name: index_repositories_on_org_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_repositories_on_org_id ON repositories USING btree (org_id);
+CREATE UNIQUE INDEX index_repositories_on_org_id ON public.repositories USING btree (org_id);
 
 
 --
 -- Name: index_repositories_on_owner_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_repositories_on_owner_id ON repositories USING btree (owner_id);
+CREATE INDEX index_repositories_on_owner_id ON public.repositories USING btree (owner_id);
 
 
 --
 -- Name: index_repositories_on_owner_name; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_repositories_on_owner_name ON repositories USING btree (owner_name);
+CREATE INDEX index_repositories_on_owner_name ON public.repositories USING btree (owner_name);
 
 
 --
 -- Name: index_repositories_on_owner_name_and_name; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_repositories_on_owner_name_and_name ON repositories USING btree (owner_name, name) WHERE (invalidated_at IS NULL);
+CREATE INDEX index_repositories_on_owner_name_and_name ON public.repositories USING btree (owner_name, name) WHERE (invalidated_at IS NULL);
 
 
 --
 -- Name: index_repositories_on_slug; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_repositories_on_slug ON repositories USING gin (((((owner_name)::text || '/'::text) || (name)::text)) gin_trgm_ops);
+CREATE INDEX index_repositories_on_slug ON public.repositories USING gin (((((owner_name)::text || '/'::text) || (name)::text)) public.gin_trgm_ops);
 
 
 --
 -- Name: index_repositories_on_updated_at; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_repositories_on_updated_at ON repositories USING btree (updated_at);
+CREATE INDEX index_repositories_on_updated_at ON public.repositories USING btree (updated_at);
 
 
 --
 -- Name: index_request_configs_on_repository_id_and_key; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_request_configs_on_repository_id_and_key ON request_configs USING btree (repository_id, key);
+CREATE INDEX index_request_configs_on_repository_id_and_key ON public.request_configs USING btree (repository_id, key);
 
 
 --
 -- Name: index_request_payloads_on_created_at_and_archived; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_request_payloads_on_created_at_and_archived ON request_payloads USING btree (created_at, archived);
+CREATE INDEX index_request_payloads_on_created_at_and_archived ON public.request_payloads USING btree (created_at, archived);
 
 
 --
 -- Name: index_request_payloads_on_request_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_request_payloads_on_request_id ON request_payloads USING btree (request_id);
+CREATE INDEX index_request_payloads_on_request_id ON public.request_payloads USING btree (request_id);
 
 
 --
 -- Name: index_request_raw_configs_on_repository_id_and_key; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_request_raw_configs_on_repository_id_and_key ON request_raw_configs USING btree (repository_id, key);
+CREATE INDEX index_request_raw_configs_on_repository_id_and_key ON public.request_raw_configs USING btree (repository_id, key);
 
 
 --
 -- Name: index_request_raw_configurations_on_request_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_request_raw_configurations_on_request_id ON request_raw_configurations USING btree (request_id);
+CREATE INDEX index_request_raw_configurations_on_request_id ON public.request_raw_configurations USING btree (request_id);
 
 
 --
 -- Name: index_request_raw_configurations_on_request_raw_config_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_request_raw_configurations_on_request_raw_config_id ON request_raw_configurations USING btree (request_raw_config_id);
+CREATE INDEX index_request_raw_configurations_on_request_raw_config_id ON public.request_raw_configurations USING btree (request_raw_config_id);
 
 
 --
 -- Name: index_request_yaml_configs_on_repository_id_and_key; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_request_yaml_configs_on_repository_id_and_key ON request_yaml_configs USING btree (repository_id, key);
+CREATE INDEX index_request_yaml_configs_on_repository_id_and_key ON public.request_yaml_configs USING btree (repository_id, key);
 
 
 --
 -- Name: index_requests_on_branch_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_requests_on_branch_id ON requests USING btree (branch_id);
+CREATE INDEX index_requests_on_branch_id ON public.requests USING btree (branch_id);
 
 
 --
 -- Name: index_requests_on_com_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_requests_on_com_id ON requests USING btree (com_id);
+CREATE UNIQUE INDEX index_requests_on_com_id ON public.requests USING btree (com_id);
 
 
 --
 -- Name: index_requests_on_commit_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_requests_on_commit_id ON requests USING btree (commit_id);
+CREATE INDEX index_requests_on_commit_id ON public.requests USING btree (commit_id);
 
 
 --
 -- Name: index_requests_on_config_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_requests_on_config_id ON requests USING btree (config_id);
+CREATE INDEX index_requests_on_config_id ON public.requests USING btree (config_id);
 
 
 --
 -- Name: index_requests_on_created_at; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_requests_on_created_at ON requests USING btree (created_at);
+CREATE INDEX index_requests_on_created_at ON public.requests USING btree (created_at);
 
 
 --
 -- Name: index_requests_on_github_guid; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_requests_on_github_guid ON requests USING btree (github_guid);
+CREATE UNIQUE INDEX index_requests_on_github_guid ON public.requests USING btree (github_guid);
 
 
 --
 -- Name: index_requests_on_head_commit; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_requests_on_head_commit ON requests USING btree (head_commit);
+CREATE INDEX index_requests_on_head_commit ON public.requests USING btree (head_commit);
 
 
 --
 -- Name: index_requests_on_org_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_requests_on_org_id ON requests USING btree (org_id);
+CREATE UNIQUE INDEX index_requests_on_org_id ON public.requests USING btree (org_id);
 
 
 --
 -- Name: index_requests_on_pull_request_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_requests_on_pull_request_id ON requests USING btree (pull_request_id);
+CREATE INDEX index_requests_on_pull_request_id ON public.requests USING btree (pull_request_id);
 
 
 --
 -- Name: index_requests_on_repository_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_requests_on_repository_id ON requests USING btree (repository_id);
+CREATE INDEX index_requests_on_repository_id ON public.requests USING btree (repository_id);
 
 
 --
 -- Name: index_requests_on_repository_id_and_id_desc; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_requests_on_repository_id_and_id_desc ON requests USING btree (repository_id, id DESC);
+CREATE INDEX index_requests_on_repository_id_and_id_desc ON public.requests USING btree (repository_id, id DESC);
 
 
 --
 -- Name: index_requests_on_tag_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_requests_on_tag_id ON requests USING btree (tag_id);
+CREATE INDEX index_requests_on_tag_id ON public.requests USING btree (tag_id);
 
 
 --
 -- Name: index_ssl_key_on_repository_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_ssl_key_on_repository_id ON ssl_keys USING btree (repository_id);
+CREATE INDEX index_ssl_key_on_repository_id ON public.ssl_keys USING btree (repository_id);
 
 
 --
 -- Name: index_ssl_keys_on_com_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_ssl_keys_on_com_id ON ssl_keys USING btree (com_id);
+CREATE UNIQUE INDEX index_ssl_keys_on_com_id ON public.ssl_keys USING btree (com_id);
 
 
 --
 -- Name: index_ssl_keys_on_org_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_ssl_keys_on_org_id ON ssl_keys USING btree (org_id);
+CREATE UNIQUE INDEX index_ssl_keys_on_org_id ON public.ssl_keys USING btree (org_id);
 
 
 --
 -- Name: index_stages_on_build_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_stages_on_build_id ON stages USING btree (build_id);
+CREATE INDEX index_stages_on_build_id ON public.stages USING btree (build_id);
 
 
 --
 -- Name: index_stages_on_com_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_stages_on_com_id ON stages USING btree (com_id);
+CREATE UNIQUE INDEX index_stages_on_com_id ON public.stages USING btree (com_id);
 
 
 --
 -- Name: index_stages_on_org_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_stages_on_org_id ON stages USING btree (org_id);
+CREATE UNIQUE INDEX index_stages_on_org_id ON public.stages USING btree (org_id);
 
 
 --
 -- Name: index_stars_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_stars_on_user_id ON stars USING btree (user_id);
+CREATE INDEX index_stars_on_user_id ON public.stars USING btree (user_id);
 
 
 --
 -- Name: index_stars_on_user_id_and_repository_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_stars_on_user_id_and_repository_id ON stars USING btree (user_id, repository_id);
+CREATE UNIQUE INDEX index_stars_on_user_id_and_repository_id ON public.stars USING btree (user_id, repository_id);
 
 
 --
 -- Name: index_stripe_events_on_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_stripe_events_on_date ON stripe_events USING btree (date);
+CREATE INDEX index_stripe_events_on_date ON public.stripe_events USING btree (date);
 
 
 --
 -- Name: index_stripe_events_on_event_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_stripe_events_on_event_id ON stripe_events USING btree (event_id);
+CREATE INDEX index_stripe_events_on_event_id ON public.stripe_events USING btree (event_id);
 
 
 --
 -- Name: index_stripe_events_on_event_type; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_stripe_events_on_event_type ON stripe_events USING btree (event_type);
+CREATE INDEX index_stripe_events_on_event_type ON public.stripe_events USING btree (event_type);
 
 
 --
 -- Name: index_tags_on_com_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_tags_on_com_id ON tags USING btree (com_id);
+CREATE UNIQUE INDEX index_tags_on_com_id ON public.tags USING btree (com_id);
 
 
 --
 -- Name: index_tags_on_last_build_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_tags_on_last_build_id ON tags USING btree (last_build_id);
+CREATE INDEX index_tags_on_last_build_id ON public.tags USING btree (last_build_id);
 
 
 --
 -- Name: index_tags_on_org_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_tags_on_org_id ON tags USING btree (org_id);
+CREATE UNIQUE INDEX index_tags_on_org_id ON public.tags USING btree (org_id);
 
 
 --
 -- Name: index_tags_on_repository_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_tags_on_repository_id ON tags USING btree (repository_id);
+CREATE INDEX index_tags_on_repository_id ON public.tags USING btree (repository_id);
 
 
 --
 -- Name: index_tags_on_repository_id_and_name; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_tags_on_repository_id_and_name ON tags USING btree (repository_id, name);
+CREATE UNIQUE INDEX index_tags_on_repository_id_and_name ON public.tags USING btree (repository_id, name);
 
 
 --
 -- Name: index_tokens_on_token; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_tokens_on_token ON tokens USING btree (token);
+CREATE INDEX index_tokens_on_token ON public.tokens USING btree (token);
 
 
 --
 -- Name: index_tokens_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_tokens_on_user_id ON tokens USING btree (user_id);
+CREATE INDEX index_tokens_on_user_id ON public.tokens USING btree (user_id);
 
 
 --
 -- Name: index_trial_allowances_on_creator_id_and_creator_type; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_trial_allowances_on_creator_id_and_creator_type ON trial_allowances USING btree (creator_id, creator_type);
+CREATE INDEX index_trial_allowances_on_creator_id_and_creator_type ON public.trial_allowances USING btree (creator_id, creator_type);
 
 
 --
 -- Name: index_trial_allowances_on_trial_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_trial_allowances_on_trial_id ON trial_allowances USING btree (trial_id);
+CREATE INDEX index_trial_allowances_on_trial_id ON public.trial_allowances USING btree (trial_id);
 
 
 --
 -- Name: index_trials_on_owner; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_trials_on_owner ON trials USING btree (owner_id, owner_type);
+CREATE INDEX index_trials_on_owner ON public.trials USING btree (owner_id, owner_type);
 
 
 --
 -- Name: index_user_beta_features_on_user_id_and_beta_feature_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_user_beta_features_on_user_id_and_beta_feature_id ON user_beta_features USING btree (user_id, beta_feature_id);
+CREATE INDEX index_user_beta_features_on_user_id_and_beta_feature_id ON public.user_beta_features USING btree (user_id, beta_feature_id);
 
 
 --
 -- Name: index_users_on_com_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_users_on_com_id ON users USING btree (com_id);
+CREATE UNIQUE INDEX index_users_on_com_id ON public.users USING btree (com_id);
 
 
 --
 -- Name: index_users_on_github_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_users_on_github_id ON users USING btree (github_id);
+CREATE UNIQUE INDEX index_users_on_github_id ON public.users USING btree (github_id);
 
 
 --
 -- Name: index_users_on_github_oauth_token; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_users_on_github_oauth_token ON users USING btree (github_oauth_token);
+CREATE UNIQUE INDEX index_users_on_github_oauth_token ON public.users USING btree (github_oauth_token);
 
 
 --
 -- Name: index_users_on_login; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_users_on_login ON users USING btree (login);
+CREATE INDEX index_users_on_login ON public.users USING btree (login);
 
 
 --
 -- Name: index_users_on_lower_login; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_users_on_lower_login ON users USING btree (lower((login)::text));
+CREATE INDEX index_users_on_lower_login ON public.users USING btree (lower((login)::text));
 
 
 --
 -- Name: index_users_on_org_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_users_on_org_id ON users USING btree (org_id);
+CREATE UNIQUE INDEX index_users_on_org_id ON public.users USING btree (org_id);
 
 
 --
 -- Name: index_users_on_updated_at; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_users_on_updated_at ON users USING btree (updated_at);
+CREATE INDEX index_users_on_updated_at ON public.users USING btree (updated_at);
 
 
 --
 -- Name: managed_repositories_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX managed_repositories_idx ON repositories USING btree (managed_by_installation_at);
+CREATE INDEX managed_repositories_idx ON public.repositories USING btree (managed_by_installation_at);
 
 
 --
 -- Name: owner_installations_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX owner_installations_idx ON installations USING btree (owner_id, owner_type) WHERE (removed_by_id IS NULL);
+CREATE UNIQUE INDEX owner_installations_idx ON public.installations USING btree (owner_id, owner_type) WHERE (removed_by_id IS NULL);
 
 
 --
 -- Name: subscriptions_owner; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX subscriptions_owner ON subscriptions USING btree (owner_id, owner_type) WHERE ((status)::text = 'subscribed'::text);
+CREATE UNIQUE INDEX subscriptions_owner ON public.subscriptions USING btree (owner_id, owner_type) WHERE ((status)::text = 'subscribed'::text);
 
 
 --
 -- Name: user_preferences_build_emails_false; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX user_preferences_build_emails_false ON users USING btree (id) WHERE ((preferences ->> 'build_emails'::text) = 'false'::text);
+CREATE INDEX user_preferences_build_emails_false ON public.users USING btree (id) WHERE ((preferences ->> 'build_emails'::text) = 'false'::text);
 
 
 --
 -- Name: branches set_unique_name_on_branches; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER set_unique_name_on_branches BEFORE INSERT OR UPDATE ON branches FOR EACH ROW EXECUTE PROCEDURE set_unique_name();
+CREATE TRIGGER set_unique_name_on_branches BEFORE INSERT OR UPDATE ON public.branches FOR EACH ROW EXECUTE PROCEDURE public.set_unique_name();
+
+
+--
+-- Name: builds set_unique_number_on_builds; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER set_unique_number_on_builds BEFORE INSERT OR UPDATE ON public.builds FOR EACH ROW EXECUTE PROCEDURE public.set_unique_number();
 
 
 --
 -- Name: builds set_updated_at_on_builds; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER set_updated_at_on_builds BEFORE INSERT OR UPDATE ON builds FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
+CREATE TRIGGER set_updated_at_on_builds BEFORE INSERT OR UPDATE ON public.builds FOR EACH ROW EXECUTE PROCEDURE public.set_updated_at();
 
 
 --
 -- Name: jobs set_updated_at_on_jobs; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER set_updated_at_on_jobs BEFORE INSERT OR UPDATE ON jobs FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
+CREATE TRIGGER set_updated_at_on_jobs BEFORE INSERT OR UPDATE ON public.jobs FOR EACH ROW EXECUTE PROCEDURE public.set_updated_at();
 
 
 --
 -- Name: branches trg_count_branch_deleted; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER trg_count_branch_deleted AFTER DELETE ON branches FOR EACH ROW WHEN ((now() > '2018-01-01 00:00:00+00'::timestamp with time zone)) EXECUTE PROCEDURE count_branches('-1');
+CREATE TRIGGER trg_count_branch_deleted AFTER DELETE ON public.branches FOR EACH ROW WHEN ((now() > '2018-01-01 00:00:00+00'::timestamp with time zone)) EXECUTE PROCEDURE public.count_branches('-1');
 
 
 --
 -- Name: branches trg_count_branch_inserted; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER trg_count_branch_inserted AFTER INSERT ON branches FOR EACH ROW WHEN ((now() > '2018-01-01 00:00:00+00'::timestamp with time zone)) EXECUTE PROCEDURE count_branches('1');
+CREATE TRIGGER trg_count_branch_inserted AFTER INSERT ON public.branches FOR EACH ROW WHEN ((now() > '2018-01-01 00:00:00+00'::timestamp with time zone)) EXECUTE PROCEDURE public.count_branches('1');
 
 
 --
 -- Name: builds trg_count_build_deleted; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER trg_count_build_deleted AFTER DELETE ON builds FOR EACH ROW WHEN ((now() > '2018-01-01 00:00:00+00'::timestamp with time zone)) EXECUTE PROCEDURE count_builds('-1');
+CREATE TRIGGER trg_count_build_deleted AFTER DELETE ON public.builds FOR EACH ROW WHEN ((now() > '2018-01-01 00:00:00+00'::timestamp with time zone)) EXECUTE PROCEDURE public.count_builds('-1');
 
 
 --
 -- Name: builds trg_count_build_inserted; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER trg_count_build_inserted AFTER INSERT ON builds FOR EACH ROW WHEN ((now() > '2018-01-01 00:00:00+00'::timestamp with time zone)) EXECUTE PROCEDURE count_builds('1');
+CREATE TRIGGER trg_count_build_inserted AFTER INSERT ON public.builds FOR EACH ROW WHEN ((now() > '2018-01-01 00:00:00+00'::timestamp with time zone)) EXECUTE PROCEDURE public.count_builds('1');
 
 
 --
 -- Name: commits trg_count_commit_deleted; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER trg_count_commit_deleted AFTER DELETE ON commits FOR EACH ROW WHEN ((now() > '2018-01-01 00:00:00+00'::timestamp with time zone)) EXECUTE PROCEDURE count_commits('-1');
+CREATE TRIGGER trg_count_commit_deleted AFTER DELETE ON public.commits FOR EACH ROW WHEN ((now() > '2018-01-01 00:00:00+00'::timestamp with time zone)) EXECUTE PROCEDURE public.count_commits('-1');
 
 
 --
 -- Name: commits trg_count_commit_inserted; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER trg_count_commit_inserted AFTER INSERT ON commits FOR EACH ROW WHEN ((now() > '2018-01-01 00:00:00+00'::timestamp with time zone)) EXECUTE PROCEDURE count_commits('1');
+CREATE TRIGGER trg_count_commit_inserted AFTER INSERT ON public.commits FOR EACH ROW WHEN ((now() > '2018-01-01 00:00:00+00'::timestamp with time zone)) EXECUTE PROCEDURE public.count_commits('1');
 
 
 --
 -- Name: jobs trg_count_job_deleted; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER trg_count_job_deleted AFTER DELETE ON jobs FOR EACH ROW WHEN ((now() > '2018-01-01 00:00:00+00'::timestamp with time zone)) EXECUTE PROCEDURE count_jobs('-1');
+CREATE TRIGGER trg_count_job_deleted AFTER DELETE ON public.jobs FOR EACH ROW WHEN ((now() > '2018-01-01 00:00:00+00'::timestamp with time zone)) EXECUTE PROCEDURE public.count_jobs('-1');
 
 
 --
 -- Name: jobs trg_count_job_inserted; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER trg_count_job_inserted AFTER INSERT ON jobs FOR EACH ROW WHEN ((now() > '2018-01-01 00:00:00+00'::timestamp with time zone)) EXECUTE PROCEDURE count_jobs('1');
+CREATE TRIGGER trg_count_job_inserted AFTER INSERT ON public.jobs FOR EACH ROW WHEN ((now() > '2018-01-01 00:00:00+00'::timestamp with time zone)) EXECUTE PROCEDURE public.count_jobs('1');
 
 
 --
 -- Name: pull_requests trg_count_pull_request_deleted; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER trg_count_pull_request_deleted AFTER DELETE ON pull_requests FOR EACH ROW WHEN ((now() > '2018-01-01 00:00:00+00'::timestamp with time zone)) EXECUTE PROCEDURE count_pull_requests('-1');
+CREATE TRIGGER trg_count_pull_request_deleted AFTER DELETE ON public.pull_requests FOR EACH ROW WHEN ((now() > '2018-01-01 00:00:00+00'::timestamp with time zone)) EXECUTE PROCEDURE public.count_pull_requests('-1');
 
 
 --
 -- Name: pull_requests trg_count_pull_request_inserted; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER trg_count_pull_request_inserted AFTER INSERT ON pull_requests FOR EACH ROW WHEN ((now() > '2018-01-01 00:00:00+00'::timestamp with time zone)) EXECUTE PROCEDURE count_pull_requests('1');
+CREATE TRIGGER trg_count_pull_request_inserted AFTER INSERT ON public.pull_requests FOR EACH ROW WHEN ((now() > '2018-01-01 00:00:00+00'::timestamp with time zone)) EXECUTE PROCEDURE public.count_pull_requests('1');
 
 
 --
 -- Name: requests trg_count_request_deleted; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER trg_count_request_deleted AFTER DELETE ON requests FOR EACH ROW WHEN ((now() > '2018-01-01 00:00:00+00'::timestamp with time zone)) EXECUTE PROCEDURE count_requests('-1');
+CREATE TRIGGER trg_count_request_deleted AFTER DELETE ON public.requests FOR EACH ROW WHEN ((now() > '2018-01-01 00:00:00+00'::timestamp with time zone)) EXECUTE PROCEDURE public.count_requests('-1');
 
 
 --
 -- Name: requests trg_count_request_inserted; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER trg_count_request_inserted AFTER INSERT ON requests FOR EACH ROW WHEN ((now() > '2018-01-01 00:00:00+00'::timestamp with time zone)) EXECUTE PROCEDURE count_requests('1');
+CREATE TRIGGER trg_count_request_inserted AFTER INSERT ON public.requests FOR EACH ROW WHEN ((now() > '2018-01-01 00:00:00+00'::timestamp with time zone)) EXECUTE PROCEDURE public.count_requests('1');
 
 
 --
 -- Name: tags trg_count_tag_deleted; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER trg_count_tag_deleted AFTER DELETE ON tags FOR EACH ROW WHEN ((now() > '2018-01-01 00:00:00+00'::timestamp with time zone)) EXECUTE PROCEDURE count_tags('-1');
+CREATE TRIGGER trg_count_tag_deleted AFTER DELETE ON public.tags FOR EACH ROW WHEN ((now() > '2018-01-01 00:00:00+00'::timestamp with time zone)) EXECUTE PROCEDURE public.count_tags('-1');
 
 
 --
 -- Name: tags trg_count_tag_inserted; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER trg_count_tag_inserted AFTER INSERT ON tags FOR EACH ROW WHEN ((now() > '2018-01-01 00:00:00+00'::timestamp with time zone)) EXECUTE PROCEDURE count_tags('1');
+CREATE TRIGGER trg_count_tag_inserted AFTER INSERT ON public.tags FOR EACH ROW WHEN ((now() > '2018-01-01 00:00:00+00'::timestamp with time zone)) EXECUTE PROCEDURE public.count_tags('1');
 
 
 --
 -- Name: branches fk_branches_on_last_build_id; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY branches
-    ADD CONSTRAINT fk_branches_on_last_build_id FOREIGN KEY (last_build_id) REFERENCES builds(id) ON DELETE SET NULL;
+ALTER TABLE ONLY public.branches
+    ADD CONSTRAINT fk_branches_on_last_build_id FOREIGN KEY (last_build_id) REFERENCES public.builds(id) ON DELETE SET NULL;
 
 
 --
 -- Name: branches fk_branches_on_repository_id; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY branches
-    ADD CONSTRAINT fk_branches_on_repository_id FOREIGN KEY (repository_id) REFERENCES repositories(id);
+ALTER TABLE ONLY public.branches
+    ADD CONSTRAINT fk_branches_on_repository_id FOREIGN KEY (repository_id) REFERENCES public.repositories(id);
 
 
 --
 -- Name: build_configs fk_build_configs_on_repository_id; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY build_configs
-    ADD CONSTRAINT fk_build_configs_on_repository_id FOREIGN KEY (repository_id) REFERENCES repositories(id);
+ALTER TABLE ONLY public.build_configs
+    ADD CONSTRAINT fk_build_configs_on_repository_id FOREIGN KEY (repository_id) REFERENCES public.repositories(id);
 
 
 --
 -- Name: builds fk_builds_on_branch_id; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY builds
-    ADD CONSTRAINT fk_builds_on_branch_id FOREIGN KEY (branch_id) REFERENCES branches(id);
+ALTER TABLE ONLY public.builds
+    ADD CONSTRAINT fk_builds_on_branch_id FOREIGN KEY (branch_id) REFERENCES public.branches(id);
 
 
 --
 -- Name: builds fk_builds_on_commit_id; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY builds
-    ADD CONSTRAINT fk_builds_on_commit_id FOREIGN KEY (commit_id) REFERENCES commits(id);
+ALTER TABLE ONLY public.builds
+    ADD CONSTRAINT fk_builds_on_commit_id FOREIGN KEY (commit_id) REFERENCES public.commits(id);
 
 
 --
 -- Name: builds fk_builds_on_config_id; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY builds
-    ADD CONSTRAINT fk_builds_on_config_id FOREIGN KEY (config_id) REFERENCES build_configs(id);
+ALTER TABLE ONLY public.builds
+    ADD CONSTRAINT fk_builds_on_config_id FOREIGN KEY (config_id) REFERENCES public.build_configs(id);
 
 
 --
 -- Name: builds fk_builds_on_pull_request_id; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY builds
-    ADD CONSTRAINT fk_builds_on_pull_request_id FOREIGN KEY (pull_request_id) REFERENCES pull_requests(id);
+ALTER TABLE ONLY public.builds
+    ADD CONSTRAINT fk_builds_on_pull_request_id FOREIGN KEY (pull_request_id) REFERENCES public.pull_requests(id);
 
 
 --
 -- Name: builds fk_builds_on_repository_id; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY builds
-    ADD CONSTRAINT fk_builds_on_repository_id FOREIGN KEY (repository_id) REFERENCES repositories(id);
+ALTER TABLE ONLY public.builds
+    ADD CONSTRAINT fk_builds_on_repository_id FOREIGN KEY (repository_id) REFERENCES public.repositories(id);
 
 
 --
 -- Name: builds fk_builds_on_request_id; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY builds
-    ADD CONSTRAINT fk_builds_on_request_id FOREIGN KEY (request_id) REFERENCES requests(id);
+ALTER TABLE ONLY public.builds
+    ADD CONSTRAINT fk_builds_on_request_id FOREIGN KEY (request_id) REFERENCES public.requests(id);
 
 
 --
 -- Name: builds fk_builds_on_tag_id; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY builds
-    ADD CONSTRAINT fk_builds_on_tag_id FOREIGN KEY (tag_id) REFERENCES tags(id);
+ALTER TABLE ONLY public.builds
+    ADD CONSTRAINT fk_builds_on_tag_id FOREIGN KEY (tag_id) REFERENCES public.tags(id);
 
 
 --
 -- Name: commits fk_commits_on_branch_id; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY commits
-    ADD CONSTRAINT fk_commits_on_branch_id FOREIGN KEY (branch_id) REFERENCES branches(id);
+ALTER TABLE ONLY public.commits
+    ADD CONSTRAINT fk_commits_on_branch_id FOREIGN KEY (branch_id) REFERENCES public.branches(id);
 
 
 --
 -- Name: commits fk_commits_on_repository_id; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY commits
-    ADD CONSTRAINT fk_commits_on_repository_id FOREIGN KEY (repository_id) REFERENCES repositories(id);
+ALTER TABLE ONLY public.commits
+    ADD CONSTRAINT fk_commits_on_repository_id FOREIGN KEY (repository_id) REFERENCES public.repositories(id);
 
 
 --
 -- Name: commits fk_commits_on_tag_id; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY commits
-    ADD CONSTRAINT fk_commits_on_tag_id FOREIGN KEY (tag_id) REFERENCES tags(id);
+ALTER TABLE ONLY public.commits
+    ADD CONSTRAINT fk_commits_on_tag_id FOREIGN KEY (tag_id) REFERENCES public.tags(id);
 
 
 --
 -- Name: crons fk_crons_on_branch_id; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY crons
-    ADD CONSTRAINT fk_crons_on_branch_id FOREIGN KEY (branch_id) REFERENCES branches(id);
+ALTER TABLE ONLY public.crons
+    ADD CONSTRAINT fk_crons_on_branch_id FOREIGN KEY (branch_id) REFERENCES public.branches(id);
 
 
 --
 -- Name: job_configs fk_job_configs_on_repository_id; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY job_configs
-    ADD CONSTRAINT fk_job_configs_on_repository_id FOREIGN KEY (repository_id) REFERENCES repositories(id);
+ALTER TABLE ONLY public.job_configs
+    ADD CONSTRAINT fk_job_configs_on_repository_id FOREIGN KEY (repository_id) REFERENCES public.repositories(id);
 
 
 --
 -- Name: jobs fk_jobs_on_commit_id; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY jobs
-    ADD CONSTRAINT fk_jobs_on_commit_id FOREIGN KEY (commit_id) REFERENCES commits(id);
+ALTER TABLE ONLY public.jobs
+    ADD CONSTRAINT fk_jobs_on_commit_id FOREIGN KEY (commit_id) REFERENCES public.commits(id);
 
 
 --
 -- Name: jobs fk_jobs_on_config_id; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY jobs
-    ADD CONSTRAINT fk_jobs_on_config_id FOREIGN KEY (config_id) REFERENCES job_configs(id);
+ALTER TABLE ONLY public.jobs
+    ADD CONSTRAINT fk_jobs_on_config_id FOREIGN KEY (config_id) REFERENCES public.job_configs(id);
 
 
 --
 -- Name: jobs fk_jobs_on_repository_id; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY jobs
-    ADD CONSTRAINT fk_jobs_on_repository_id FOREIGN KEY (repository_id) REFERENCES repositories(id);
+ALTER TABLE ONLY public.jobs
+    ADD CONSTRAINT fk_jobs_on_repository_id FOREIGN KEY (repository_id) REFERENCES public.repositories(id);
 
 
 --
 -- Name: jobs fk_jobs_on_stage_id; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY jobs
-    ADD CONSTRAINT fk_jobs_on_stage_id FOREIGN KEY (stage_id) REFERENCES stages(id);
+ALTER TABLE ONLY public.jobs
+    ADD CONSTRAINT fk_jobs_on_stage_id FOREIGN KEY (stage_id) REFERENCES public.stages(id);
 
 
 --
 -- Name: pull_requests fk_pull_requests_on_repository_id; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY pull_requests
-    ADD CONSTRAINT fk_pull_requests_on_repository_id FOREIGN KEY (repository_id) REFERENCES repositories(id);
+ALTER TABLE ONLY public.pull_requests
+    ADD CONSTRAINT fk_pull_requests_on_repository_id FOREIGN KEY (repository_id) REFERENCES public.repositories(id);
 
 
 --
 -- Name: installations fk_rails_2d567d406d; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY installations
-    ADD CONSTRAINT fk_rails_2d567d406d FOREIGN KEY (added_by_id) REFERENCES users(id);
+ALTER TABLE ONLY public.installations
+    ADD CONSTRAINT fk_rails_2d567d406d FOREIGN KEY (added_by_id) REFERENCES public.users(id);
 
 
 --
 -- Name: installations fk_rails_75a0a2a3b4; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY installations
-    ADD CONSTRAINT fk_rails_75a0a2a3b4 FOREIGN KEY (removed_by_id) REFERENCES users(id);
+ALTER TABLE ONLY public.installations
+    ADD CONSTRAINT fk_rails_75a0a2a3b4 FOREIGN KEY (removed_by_id) REFERENCES public.users(id);
 
 
 --
 -- Name: repositories fk_repositories_on_current_build_id; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY repositories
-    ADD CONSTRAINT fk_repositories_on_current_build_id FOREIGN KEY (current_build_id) REFERENCES builds(id) ON DELETE SET NULL;
+ALTER TABLE ONLY public.repositories
+    ADD CONSTRAINT fk_repositories_on_current_build_id FOREIGN KEY (current_build_id) REFERENCES public.builds(id) ON DELETE SET NULL;
 
 
 --
 -- Name: repositories fk_repositories_on_last_build_id; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY repositories
-    ADD CONSTRAINT fk_repositories_on_last_build_id FOREIGN KEY (last_build_id) REFERENCES builds(id) ON DELETE SET NULL;
+ALTER TABLE ONLY public.repositories
+    ADD CONSTRAINT fk_repositories_on_last_build_id FOREIGN KEY (last_build_id) REFERENCES public.builds(id) ON DELETE SET NULL;
 
 
 --
 -- Name: requests fk_requests_on_branch_id; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY requests
-    ADD CONSTRAINT fk_requests_on_branch_id FOREIGN KEY (branch_id) REFERENCES branches(id);
+ALTER TABLE ONLY public.requests
+    ADD CONSTRAINT fk_requests_on_branch_id FOREIGN KEY (branch_id) REFERENCES public.branches(id);
 
 
 --
 -- Name: requests fk_requests_on_commit_id; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY requests
-    ADD CONSTRAINT fk_requests_on_commit_id FOREIGN KEY (commit_id) REFERENCES commits(id);
+ALTER TABLE ONLY public.requests
+    ADD CONSTRAINT fk_requests_on_commit_id FOREIGN KEY (commit_id) REFERENCES public.commits(id);
 
 
 --
 -- Name: requests fk_requests_on_config_id; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY requests
-    ADD CONSTRAINT fk_requests_on_config_id FOREIGN KEY (config_id) REFERENCES request_configs(id);
+ALTER TABLE ONLY public.requests
+    ADD CONSTRAINT fk_requests_on_config_id FOREIGN KEY (config_id) REFERENCES public.request_configs(id);
 
 
 --
 -- Name: requests fk_requests_on_pull_request_id; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY requests
-    ADD CONSTRAINT fk_requests_on_pull_request_id FOREIGN KEY (pull_request_id) REFERENCES pull_requests(id);
+ALTER TABLE ONLY public.requests
+    ADD CONSTRAINT fk_requests_on_pull_request_id FOREIGN KEY (pull_request_id) REFERENCES public.pull_requests(id);
 
 
 --
 -- Name: requests fk_requests_on_tag_id; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY requests
-    ADD CONSTRAINT fk_requests_on_tag_id FOREIGN KEY (tag_id) REFERENCES tags(id);
+ALTER TABLE ONLY public.requests
+    ADD CONSTRAINT fk_requests_on_tag_id FOREIGN KEY (tag_id) REFERENCES public.tags(id);
 
 
 --
 -- Name: ssl_keys fk_ssl_keys_on_repository_id; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY ssl_keys
-    ADD CONSTRAINT fk_ssl_keys_on_repository_id FOREIGN KEY (repository_id) REFERENCES repositories(id);
+ALTER TABLE ONLY public.ssl_keys
+    ADD CONSTRAINT fk_ssl_keys_on_repository_id FOREIGN KEY (repository_id) REFERENCES public.repositories(id);
 
 
 --
 -- Name: stages fk_stages_on_build_id; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY stages
-    ADD CONSTRAINT fk_stages_on_build_id FOREIGN KEY (build_id) REFERENCES builds(id);
+ALTER TABLE ONLY public.stages
+    ADD CONSTRAINT fk_stages_on_build_id FOREIGN KEY (build_id) REFERENCES public.builds(id);
 
 
 --
 -- Name: tags fk_tags_on_last_build_id; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY tags
-    ADD CONSTRAINT fk_tags_on_last_build_id FOREIGN KEY (last_build_id) REFERENCES builds(id) ON DELETE SET NULL;
+ALTER TABLE ONLY public.tags
+    ADD CONSTRAINT fk_tags_on_last_build_id FOREIGN KEY (last_build_id) REFERENCES public.builds(id) ON DELETE SET NULL;
 
 
 --
 -- Name: tags fk_tags_on_repository_id; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY tags
-    ADD CONSTRAINT fk_tags_on_repository_id FOREIGN KEY (repository_id) REFERENCES repositories(id);
+ALTER TABLE ONLY public.tags
+    ADD CONSTRAINT fk_tags_on_repository_id FOREIGN KEY (repository_id) REFERENCES public.repositories(id);
 
 
 --
@@ -4972,6 +5000,9 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190118000000'),
 ('20190204000000'),
 ('20190313000000'),
-('20190329093854');
+('20190329093854'),
+('20190409133118'),
+('20190409133320'),
+('20190409133444');
 
 


### PR DESCRIPTION
We can't add a unique index on a (repository_id, number) columns pair on
the builds table because we have duplicates in the table that we can't
really get rid of. That's why I came up with a way to ensure uniqueness
on the database level without adding a unique index to the number column
itself, but a unique_number column which is set on INSERT and UPDATE to
the builds table.

I used a similar thing when cleaning up the branches, so it's already
proved to work