### PR TITLE
Run set_unique_number only on INSERT

### DIFF
--- a/db/main/migrate/20190410121039_make_set_unique_number_trigger_run_only_on_insert.rb
+++ b/db/main/migrate/20190410121039_make_set_unique_number_trigger_run_only_on_insert.rb
@@ -1,0 +1,21 @@
+class MakeSetUniqueNumberTriggerRunOnlyOnInsert < ActiveRecord::Migration[5.2]
+  def up
+    execute <<-SQL
+      DROP TRIGGER set_unique_number_on_builds ON builds;
+      CREATE TRIGGER set_unique_number_on_builds
+      BEFORE INSERT ON builds
+      FOR EACH ROW
+      EXECUTE PROCEDURE set_unique_number();
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      DROP TRIGGER set_unique_number_on_builds ON builds;
+      CREATE TRIGGER set_unique_number_on_builds
+      BEFORE INSERT OR UPDATE ON builds
+      FOR EACH ROW
+      EXECUTE PROCEDURE set_unique_number();
+    SQL
+  end
+end

--- a/db/main/structure.sql
+++ b/db/main/structure.sql
@@ -4292,7 +4292,7 @@ CREATE TRIGGER set_unique_name_on_branches BEFORE INSERT OR UPDATE ON public.bra
 -- Name: builds set_unique_number_on_builds; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER set_unique_number_on_builds BEFORE INSERT OR UPDATE ON public.builds FOR EACH ROW EXECUTE PROCEDURE public.set_unique_number();
+CREATE TRIGGER set_unique_number_on_builds BEFORE INSERT ON public.builds FOR EACH ROW EXECUTE PROCEDURE public.set_unique_number();
 
 
 --
@@ -5003,6 +5003,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190329093854'),
 ('20190409133118'),
 ('20190409133320'),
-('20190409133444');
+('20190409133444'),
+('20190410121039');
 
 


### PR DESCRIPTION
If the set_unique_number procedure runs on UPDATE on the builds table we
could run into problems when trying to update builds that have
duplicated number. That's why we should run it only on INSERT. It's
still fine for consistency because we generally don't modify build
numbers.