### PR TITLE
Allow to skip setting unique_number

### DIFF
--- a/db/main/migrate/20190417072423_alter_builds_unique_number_index.rb
+++ b/db/main/migrate/20190417072423_alter_builds_unique_number_index.rb
@@ -1,0 +1,15 @@
+class AlterBuildsUniqueNumberIndex < ActiveRecord::Migration[5.2]
+  self.disable_ddl_transaction!
+
+  def up
+    execute "CREATE UNIQUE INDEX CONCURRENTLY index_builds_repository_id_unique_number_new ON builds(repository_id, unique_number) WHERE unique_number IS NOT NULL AND unique_number > 0"
+    execute "DROP INDEX CONCURRENTLY index_builds_repository_id_unique_number"
+    execute "ALTER INDEX index_builds_repository_id_unique_number_new RENAME TO index_builds_repository_id_unique_number"
+  end
+
+  def down
+    execute "CREATE UNIQUE INDEX CONCURRENTLY index_builds_repository_id_unique_number_new ON builds(repository_id, unique_number) WHERE unique_number IS NOT NULL"
+    execute "DROP INDEX CONCURRENTLY index_builds_repository_id_unique_number"
+    execute "ALTER INDEX index_builds_repository_id_unique_number_new RENAME TO index_builds_repository_id_unique_number"
+  end
+end

--- a/db/main/migrate/20190417072838_reinstall_set_unique_number_trigger.rb
+++ b/db/main/migrate/20190417072838_reinstall_set_unique_number_trigger.rb
@@ -1,0 +1,9 @@
+class ReinstallSetUniqueNumberTrigger < ActiveRecord::Migration[5.2]
+  def up
+    execute File.read(Rails.root.join('db/main/sql/triggers/drop_set_unique_number.sql'))
+    execute File.read(Rails.root.join('db/main/sql/triggers/create_set_unique_number.sql'))
+  end
+
+  def down
+  end
+end

--- a/db/main/sql/triggers/create_set_unique_number.sql
+++ b/db/main/sql/triggers/create_set_unique_number.sql
@@ -14,7 +14,9 @@ BEGIN
     END;
 
     IF NOT disable THEN
-      NEW.unique_number := NEW.number;
+      IF NEW.unique_number IS NULL OR NEW.unique_number > 0 THEN
+        NEW.unique_number := NEW.number;
+      END IF;
     END IF;
   END IF;
   RETURN NEW;

--- a/spec/set_unique_number_spec.rb
+++ b/spec/set_unique_number_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+require 'yaml'
+
+describe 'set_updated_at trigger' do
+  def run(cmd)
+    system "RAILS_ENV=test bundle exec #{cmd}"
+    expect($?.exitstatus).to eq 0
+  end
+
+  let(:config) { YAML.load(ERB.new(File.read('config/database.yml')).result) }
+  before(:all) do
+    run 'rake db:drop db:create db:migrate'
+  end
+
+  before { ActiveRecord::Base.establish_connection(config['test']) }
+  after { ActiveRecord::Base.remove_connection }
+
+  before do
+    conn.execute('TRUNCATE builds CASCADE;')
+  end
+
+  let(:conn)   { ActiveRecord::Base.connection }
+
+  def e(query)
+    conn.execute(query)
+  end
+
+  def s(query)
+    conn.select_one(query)
+  end
+
+  it 'sets unique_number on INSERT' do
+    e "INSERT INTO repositories (id, created_at, updated_at) VALUES(1, now(), now())"
+    e "INSERT INTO builds (repository_id, number, created_at, updated_at) VALUES (1, '1', now(), now());"
+    result = s "SELECT unique_number FROM builds"
+    expect(result['unique_number']).to eql(1)
+  end
+
+  it 'does not set unique_number on INSERT if 0 is given as a value' do
+    e "INSERT INTO repositories (id, created_at, updated_at) VALUES(1, now(), now())"
+    e "INSERT INTO builds (repository_id, number, unique_number, created_at, updated_at) VALUES (1, '1', 0, now(), now());"
+    result = s "SELECT unique_number FROM builds"
+    expect(result['unique_number']).to eql(0)
+  end
+
+  it 'sets unique_number on UPDATE' do
+    e "INSERT INTO repositories (id, created_at, updated_at) VALUES(1, now(), now())"
+    e "INSERT INTO builds (repository_id, number, created_at, updated_at) VALUES (1, '1', now(), now());"
+    e "UPDATE builds SET number = '2';"
+    result = s "SELECT unique_number FROM builds"
+    expect(result['unique_number']).to eql(2)
+  end
+
+  it 'does not set unique_number on UPDATE if unique_number is 0' do
+    e "INSERT INTO repositories (id, created_at, updated_at) VALUES(1, now(), now())"
+    e "INSERT INTO builds (repository_id, number, unique_number, created_at, updated_at) VALUES (1, '1', 0, now(), now());"
+    e "UPDATE builds SET number = '2';"
+    result = s "SELECT unique_number FROM builds"
+    expect(result['unique_number']).to eql(0)
+  end
+end


### PR DESCRIPTION
Initially I wanted to not update unique_number when performing an UPDATE
to make things simple but after giving it more thought I decided that
it's better to be able to do it on both UPDATE and INSERT. Normally we
don't update builds.number but it might still be valuable to have the
consistency when doing some kind of meintenance (like renumbering
builds).