### PR TITLE
Add index to job_versions on job_id

### DIFF
--- a/db/main/migrate/20200214144655_add_index_to_job_versions_on_job_id.rb
+++ b/db/main/migrate/20200214144655_add_index_to_job_versions_on_job_id.rb
@@ -1,0 +1,7 @@
+class AddIndexToJobVersionsOnJobId < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :job_versions, :job_id, algorithm: :concurrently
+  end
+end


### PR DESCRIPTION
We have a slowish query currently when querying `job_versions` (appears to be executed whenever we restart a job):

```sql
SELECT MAX("job_versions"."number")
FROM "job_versions"
WHERE "job_versions"."job_id" = $1
```
I created 100k rows locally and ran the query, average execution time: 15-24ms.

I then added this index. Average query execution time: 0.3-0.5ms.