### PR TITLE
added the new column to support the internation vat ids

### DIFF
--- a/db/main/migrate/20202427123653_add_column_has_local_registration_to_table_subscriptions.rb
+++ b/db/main/migrate/20202427123653_add_column_has_local_registration_to_table_subscriptions.rb
@@ -1,0 +1,13 @@
+class AddColumnHasLocalRegistrationToTableSubscriptions < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def up
+    add_column :subscriptions, :has_local_registration, :boolean, default: nil
+  end
+
+  def down
+    ActiveRecord::Base.transaction do
+      remove_column :subscriptions, :has_local_registration
+    end
+  end
+end


### PR DESCRIPTION
The new column is required by the accounts department.

> We need to have a mandatory question: “Is your company registered locally for VAT/GST”
> If reply is “Yes” – customer needs to complete mandatory field “Tax ID”
> If “No” – customer proceeds with order
> 
> **We will need to be able to extract a report where customer answered “No”, as this will mean customer B2C and we need to track the threshold manually