### PR TITLE
Remove snap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ services:
   - postgresql
 
 addons:
-  - snaps:
-    - name: docker
-      channel: latest/beta
   - postgresql: "11"
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ after_success:
 jobs:
   include:
     - stage: "Testing time"
+      dist: focal
       script:
         - bundle exec rspec spec
     - stage: "Ship to Quay.io"

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,15 @@ jobs:
     - stage: "Testing time"
       dist: focal
       language: ruby
+      addons:
+        postgresql: "11"
+        apt:
+          sources:
+            - sourceline: 'deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main'
+              key_url: 'https://www.postgresql.org/media/keys/ACCC4CF8.asc'
+          packages:
+            - postgresql-11
+            - postgresql-client-11
       script:
         - bundle exec rspec spec
     - stage: "Ship to Quay.io"

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ jobs:
   include:
     - stage: "Testing time"
       dist: focal
-      language: minimal
+      language: ruby
       script:
         - bundle exec rspec spec
     - stage: "Ship to Quay.io"

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,15 @@ jobs:
           packages:
             - postgresql-11
             - postgresql-client-11
+      before_install:
+        - gem update --system
+        - sudo sed -i -e '/local.*peer/s/postgres/all/' -e 's/peer\|md5/trust/g' /etc/postgresql/11/main/pg_hba.conf
+        - sudo sed -i -e 's/^port = 5433/port = 5432/' /etc/postgresql/11/main/postgresql.conf
+        - sudo systemctl restart postgresql@11-main
+      before_script:
+        - psql --version
+        - psql -c 'CREATE DATABASE travis_test;'
+        - curl -fs https://raw.githubusercontent.com/travis-ci/travis-migrations/master/db/main/structure.sql | psql -v ON_ERROR_STOP=1 travis_test
       script:
         - bundle exec rspec spec
     - stage: "Ship to Quay.io"

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ jobs:
   include:
     - stage: "Testing time"
       dist: focal
+      language: minimal
       script:
         - bundle exec rspec spec
     - stage: "Ship to Quay.io"


### PR DESCRIPTION
This PR removes snap because It was added in the past to support outdated docker and for reason it was causing issues with Quay.